### PR TITLE
Update EditorController.php for Nextcloud 34 Compatibility

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -696,8 +696,10 @@ class EditorController extends Controller
             $csp->addAllowedScriptDomain($drawioUrl);
             $csp->addAllowedFrameDomain($drawioUrl);
             $csp->addAllowedFrameDomain("blob:");
-            $csp->addAllowedChildSrcDomain($drawioUrl);
-            $csp->addAllowedChildSrcDomain("blob:");
+			if (method_exists($csp, 'addAllowedChildSrcDomain')) {
+            	$csp->addAllowedChildSrcDomain($drawioUrl);
+            	$csp->addAllowedChildSrcDomain("blob:");
+			}
         }
         $response->setContentSecurityPolicy($csp);
 


### PR DESCRIPTION
## Summary

It seems Nextcloud 34 not use addAllowedChildSrcDomain anymore in CSP.

## Related issues

Fixes #2

## Testing

- [x] Tested against the [test checklist](../blob/main/DEV.md#test-checklist) (relevant sections)
- [x] Ran `npm run build` successfully
