### PR TITLE
Fix release workflow for new repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -58,6 +61,6 @@ jobs:
         sleep 60
         echo "${{ secrets.NEXTCLOUD_KEY }}" > drawio.key
         export signature=`openssl dgst -sha512 -sign drawio.key ${{ steps.vars.outputs.tar_file_name }} | openssl base64`
-        export requestJSON="{\"download\":\"https://github.com/jgraph/drawio-nextcloud/releases/download/${GITHUB_REF##*/}/drawio-${GITHUB_REF##*/}.tar.gz\", \"signature\": \"${signature//$'\n'/\\n}\"}"
+        export requestJSON="{\"download\":\"https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF##*/}/drawio-${GITHUB_REF##*/}.tar.gz\", \"signature\": \"${signature//$'\n'/\\n}\"}"
         curl -X POST https://apps.nextcloud.com/api/v1/apps/releases -H "Authorization: Token ${{ secrets.NEXTCLOUD_TOKEN }}" -H "Content-Type: application/json" -d "${requestJSON}"
 


### PR DESCRIPTION
The `v4.2.4` release workflow failed at the **Upload Release** step with `Error 403: Resource not accessible by integration`. Two fixes, both needed for a clean release from this repo:

### 1. `GITHUB_TOKEN` permissions (the 403)
The build succeeded, but `ncipollo/release-action` couldn't create the GitHub Release because the token was read-only. Newly-created repos default the Actions `GITHUB_TOKEN` to read-only; the workflow had no `permissions:` block, so it inherited that default. Added:

```yaml
permissions:
  contents: write
```

This is a personal repo (no org-wide policy cap), so the workflow-level block overrides the read-only default.

### 2. Hardcoded App Store download URL
The **Upload App Release** step still pointed the Nextcloud App Store at `jgraph/drawio-nextcloud` releases, which don't have this repo's tarball — the publish would 404 or register the wrong build. Switched to `${GITHUB_REPOSITORY}` so it always references this repo.

### Re-running
The `v4.2.4` tag already exists but produced no release. After merging, delete and re-push `v4.2.4` (pointing at the new commit) or bump to `v4.2.5` to re-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)