### PR TITLE
fix: editor not using whole screen

### DIFF
--- a/css/editor.css
+++ b/css/editor.css
@@ -11,6 +11,7 @@
 #content.app-drawio {
     margin: 0;
     height: 100%;
+    width: 100%;
     padding-block-end: 0 !important;
     z-index: 2147483647;
 }


### PR DESCRIPTION
## Summary

This ensures that the editor covers the whole screen and does not leave a gap on the right.

It overrides the default with of `#content` which is `calc(100% - var(--body-container-margin)*2);` (at least on Nextcloud 34)

### before

<img width="1920" height="1046" alt="before" src="https://github.com/user-attachments/assets/d471e8ad-51cb-4c42-b7ba-cb4a37ef5055" />

### after

<img width="1920" height="1046" alt="after" src="https://github.com/user-attachments/assets/63e8e0be-ea47-4dab-9402-364255fcc542" />
