### PR TITLE
fix: honour the "Enable whiteboards?" setting in the new file menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ When a draw.io editor URL is pasted into Nextcloud Text, Collectives, Talk, Note
 5. Smart Picker (`/` menu) lists "Draw.io Diagrams" via `ISearchableReferenceProvider`
 
 ### Template Creator
-`RegisterTemplateCreatorListener` registers `.drawio` and `.dwb` as file types in the Nextcloud "+" new file menu via `RegisterTemplateCreatorEvent`. This also enables creating diagrams as Text document attachments (stored in `.attachments.{docId}/` folders). The editor detects attachment paths on close and redirects to the parent document.
+`RegisterTemplateCreatorListener` registers `.drawio` and `.dwb` as file types in the Nextcloud "+" new file menu via `RegisterTemplateCreatorEvent`. The `.dwb` whiteboard creator is only registered when the "Enable whiteboards?" admin setting (`AppConfig::GetWhiteboards`) is `yes`. This also enables creating diagrams as Text document attachments (stored in `.attachments.{docId}/` folders). The editor detects attachment paths on close and redirects to the parent document.
 
 ### API Routes (all under `/apps/drawio/`)
 | Method | URL                    | Controller Method        |

--- a/lib/Listeners/RegisterTemplateCreatorListener.php
+++ b/lib/Listeners/RegisterTemplateCreatorListener.php
@@ -2,6 +2,7 @@
 
 namespace OCA\Drawio\Listeners;
 
+use OCA\Drawio\AppConfig;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Template\RegisterTemplateCreatorEvent;
@@ -15,6 +16,7 @@ class RegisterTemplateCreatorListener implements IEventListener {
 
     public function __construct(
         private IL10N $l10n,
+        private AppConfig $config,
     ) {
     }
 
@@ -30,6 +32,12 @@ class RegisterTemplateCreatorListener implements IEventListener {
             $drawio->setActionLabel($this->l10n->t('New Diagram'));
             return $drawio;
         });
+
+        // The admin setting "Enable whiteboards?" hides the whiteboard
+        // entry from the file creation menu.
+        if ($this->config->GetWhiteboards() !== 'yes') {
+            return;
+        }
 
         $event->getTemplateManager()->registerTemplateFileCreator(function () {
             $dwb = new TemplateFileCreator('drawio', $this->l10n->t('New Whiteboard'), '.dwb');

--- a/tests/unit/Listeners/RegisterTemplateCreatorListenerTest.php
+++ b/tests/unit/Listeners/RegisterTemplateCreatorListenerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OCA\Drawio\Tests\Unit\Listeners;
 
+use OCA\Drawio\AppConfig;
 use OCA\Drawio\Listeners\RegisterTemplateCreatorListener;
 use OCP\EventDispatcher\Event;
 use OCP\Files\Template\ITemplateManager;
@@ -14,10 +15,14 @@ use PHPUnit\Framework\TestCase;
 
 final class RegisterTemplateCreatorListenerTest extends TestCase {
 
-    private function createListener(): RegisterTemplateCreatorListener {
+    private function createListener(string $whiteboards = 'yes'): RegisterTemplateCreatorListener {
         $l10n = $this->createMock(IL10N::class);
         $l10n->method('t')->willReturnCallback(static fn (string $text, $params = []) => $text);
-        return new RegisterTemplateCreatorListener($l10n);
+
+        $config = $this->createMock(AppConfig::class);
+        $config->method('GetWhiteboards')->willReturn($whiteboards);
+
+        return new RegisterTemplateCreatorListener($l10n, $config);
     }
 
     /**
@@ -37,7 +42,7 @@ final class RegisterTemplateCreatorListenerTest extends TestCase {
     }
 
     public function testRegistersDiagramAndWhiteboardCreators(): void {
-        $creators = $this->dispatchAndCollectCreators($this->createListener());
+        $creators = $this->dispatchAndCollectCreators($this->createListener('yes'));
 
         $this->assertCount(2, $creators);
 
@@ -53,6 +58,25 @@ final class RegisterTemplateCreatorListenerTest extends TestCase {
         $this->assertSame(['application/x-drawio-wb'], $whiteboardData['mimetypes']);
         $this->assertSame('New Whiteboard', $whiteboardData['actionLabel']);
         $this->assertStringContainsString('<svg', $whiteboardData['iconSvgInline']);
+    }
+
+    /**
+     * Regression test: the admin setting "Enable whiteboards?" promises to hide
+     * the "New Whiteboard" entry from the file creation menu, but the listener
+     * used to register both creators unconditionally.
+     */
+    public function testWhiteboardCreatorIsSkippedWhenWhiteboardsDisabled(): void {
+        $creators = $this->dispatchAndCollectCreators($this->createListener('no'));
+
+        $this->assertCount(1, $creators);
+        $this->assertSame('.drawio', $creators[0]->jsonSerialize()['extension']);
+    }
+
+    public function testDiagramCreatorIsAlwaysRegistered(): void {
+        $creators = $this->dispatchAndCollectCreators($this->createListener('no'));
+
+        $this->assertNotEmpty($creators);
+        $this->assertSame('New Diagram', $creators[0]->jsonSerialize()['actionLabel']);
     }
 
     public function testIgnoresUnrelatedEvents(): void {


### PR DESCRIPTION
## Summary

The admin settings page states that turning whiteboards off hides the "New Whiteboard" entry from the file creation menu, but nothing enforced it: the listener registered the .drawio and .dwb template creators unconditionally, so the entry stayed visible whatever the setting said.

The whiteboard creator is now only registered when the setting is enabled. Diagrams are unaffected, and existing .dwb files still open in the editor - the setting only controls file creation.

## Testing

- [x] Tested against the [test checklist](../blob/main/DEV.md#test-checklist) (relevant sections)
- [x] Ran `npm run build` successfully
