### PR TITLE
test: add an end-to-end suite against a running Nextcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,41 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    name: end-to-end (Nextcloud 33)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Start Nextcloud
+        run: docker compose up -d
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Wait for Nextcloud
+        run: |
+          for i in $(seq 1 60); do
+            if curl -s http://localhost:8088/status.php | grep -q '"installed":true'; then
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Nextcloud did not come up in time"
+          docker compose logs nextcloud | tail -50
+          exit 1
+
+      - name: Enable drawio app
+        run: docker compose exec -T -u 33 nextcloud php occ app:enable drawio
+
+      - name: Run end-to-end tests
+        run: composer run test:e2e
+        env:
+          NEXTCLOUD_E2E_BASE_URL: http://localhost:8088

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,31 @@ jobs:
           exit 1
 
       - name: Enable drawio app
-        run: docker compose exec -T -u 33 nextcloud php occ app:enable drawio
+        run: |
+          docker compose exec -T -u 33 nextcloud php occ app:enable drawio
+          # occ runs in its own process while Nextcloud caches the list of
+          # enabled apps in APCu, which the web server does not share. Without
+          # this restart the web tier can still consider the app disabled, which
+          # makes every authenticated app route answer 404.
+          docker compose restart nextcloud
+
+      - name: Wait for the app to be served
+        run: |
+          for i in $(seq 1 40); do
+            if curl -s -u admin:admin "http://localhost:8088/index.php/apps/drawio/edit?fileId=1" | grep -q iframeEditor; then
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "The drawio app did not become reachable"
+          docker compose exec -T -u 33 nextcloud php occ app:list | head -40
+          exit 1
 
       - name: Run end-to-end tests
         run: composer run test:e2e
         env:
           NEXTCLOUD_E2E_BASE_URL: http://localhost:8088
+
+      - name: Nextcloud log on failure
+        if: failure()
+        run: docker compose exec -T -u 33 nextcloud tail -n 100 data/nextcloud.log || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ npm ci
 ```
 Then open http://localhost:8088 (admin / admin). PHP changes are live (volume-mounted); JS changes require `npm run build`.
 
-**Important:** Do not change the app version in `info.xml` during development — it will break the Nextcloud instance.
+**Important:** Do not change the app version in `info.xml` during development — Nextcloud disables the app until the upgrade is applied, and the e2e suite then fails with confusing 403/404 errors. After a version bump, run `docker compose exec -u 33 nextcloud php occ upgrade` before testing again.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,8 @@ css/               Stylesheets (editor, settings)
 img/               SVG icons (app, app-dark, drawio file type, whiteboard)
 l10n/              Translations (~100 languages, managed in-repo)
 scripts/           Build/maintenance scripts (extract-strings.js, dev-setup.sh, dev-rebuild.sh)
-tests/             PHPUnit unit tests (tests/unit) and psalm stubs (tests/stubs)
-.github/workflows/ CI: lint/psalm/phpunit/build (ci.yml), release pipeline (release.yml), stale bot (stale.yml)
+tests/             PHPUnit unit tests (tests/unit), end-to-end tests (tests/e2e), harness (tests/support) and psalm stubs (tests/stubs)
+.github/workflows/ CI: lint/psalm/phpunit/e2e/build (ci.yml), release pipeline (release.yml), stale bot (stale.yml)
 ```
 
 ## Build & Development
@@ -59,6 +59,7 @@ composer update         # Install PHP dev tooling (nextcloud/ocp, psalm, phpunit
 composer run lint       # php -l over lib/, appinfo/, templates/, tests/
 composer run psalm      # Static analysis against the nextcloud/ocp API
 composer run test:unit  # PHPUnit unit tests (tests/unit)
+composer run test:e2e   # PHPUnit end-to-end tests (tests/e2e) against a running instance
 ```
 To check against Nextcloud 34 instead of 33: `composer require --dev nextcloud/ocp:dev-stable34` then `composer run psalm` (CI runs both).
 
@@ -70,6 +71,7 @@ xmllint --noout --schema /tmp/info.xsd appinfo/info.xml
 
 ### Test suite layout
 - `tests/unit/` — PHPUnit tests, one test class per production class. Covers EditorController (load/save/create/index/versions incl. locking, ETag conflicts and share permissions), SettingsController, AppConfig, PublicShareAuth, DrawioReferenceProvider, DrawioPreview, all listeners, both MIME repair steps, the Settings classes and appinfo/info.xml invariants (version sync with package.json, repair-step element names).
+- `tests/e2e/` — end-to-end tests over HTTP against a **running** Nextcloud (start with `./scripts/dev-setup.sh`; the whole suite skips if the instance is unreachable). Configuration via `NEXTCLOUD_E2E_BASE_URL` (default `http://localhost:8088`), `NEXTCLOUD_E2E_ADMIN_USER`/`NEXTCLOUD_E2E_ADMIN_PASSWORD` (default admin/admin). Covers WebDAV MIME detection, load/save round trips with ETag conflicts, previews, versions, the editor page CSP, the full anonymous password-share flow (deny → wrong password → authenticate → read → editable-share write) and the settings/whiteboards toggle via the templates API. Authenticated calls use cookie-less basic auth + the `OCS-APIRequest: true` header (passes the CSRF check); the anonymous share flow uses a real cookie jar + the `data-requesttoken` scraped from the share page. Admin language is pinned to `en` so message assertions are deterministic. From another container, target `http://host.docker.internal:8088` (a trusted domain in docker-compose.yml).
 - `tests/support/` — runtime shims that make OCP static helpers work without a server: `legacy-oc.php` (minimal `OC`, `OC_Util`, `OC\AppScriptDependency`, `OC\Hooks\Emitter`), `FakeServerContainer` (installed as `\OC::$server`), `ResetsGlobalState` trait (resets `\OCP\Util` script registries between tests).
 - `tests/doubles` equivalents live in `tests/support/oca-doubles.php` — real (not psalm-only) declarations of `OCA\Files\Event\LoadAdditionalScriptsEvent`, `OCA\Files_Sharing\Event\BeforeTemplateRenderedEvent` and the `OCA\Files_Versions` interfaces, mirroring server stable33.
 - `tests/stubs/*.phpstub` — psalm-only stubs; keep them in sync with oca-doubles.php when server APIs change.

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         }
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^7.9",
         "nextcloud/ocp": "dev-stable33",
         "phpunit/phpunit": "^10.5",
         "vimeo/psalm": "^6.0"
@@ -27,7 +28,8 @@
     "scripts": {
         "lint": "find lib appinfo templates tests -name \"*.php\" -print0 | xargs -0 -n1 php -l",
         "psalm": "psalm --no-cache --threads=1",
-        "test:unit": "phpunit --testsuite unit"
+        "test:unit": "phpunit --testsuite unit",
+        "test:e2e": "phpunit --testsuite e2e"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       MYSQL_PASSWORD: nextcloud
       NEXTCLOUD_ADMIN_USER: admin
       NEXTCLOUD_ADMIN_PASSWORD: admin
+      # host.docker.internal allows running the e2e test suite from another
+      # container (composer run test:e2e), see CLAUDE.md
+      NEXTCLOUD_TRUSTED_DOMAINS: localhost host.docker.internal
     volumes:
       - nextcloud-data:/var/www/html
       - ./appinfo:/var/www/html/custom_apps/drawio/appinfo:ro

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,5 +10,8 @@
         <testsuite name="unit">
             <directory>tests/unit</directory>
         </testsuite>
+        <testsuite name="e2e">
+            <directory>tests/e2e</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,4 @@ require_once __DIR__ . '/support/legacy-oc.php';
 require_once __DIR__ . '/support/FakeServerContainer.php';
 require_once __DIR__ . '/support/ResetsGlobalState.php';
 require_once __DIR__ . '/support/oca-doubles.php';
+require_once __DIR__ . '/e2e/E2ETestCase.php';

--- a/tests/e2e/E2ETestCase.php
+++ b/tests/e2e/E2ETestCase.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Drawio\Tests\E2e;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Cookie\CookieJar;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for end-to-end tests against a running Nextcloud instance
+ * (scripts/dev-setup.sh / docker-compose.yml).
+ *
+ * Configuration via environment:
+ * - NEXTCLOUD_E2E_BASE_URL  (default http://localhost:8088)
+ * - NEXTCLOUD_E2E_ADMIN_USER / NEXTCLOUD_E2E_ADMIN_PASSWORD (default admin/admin)
+ *
+ * The whole class is skipped when the instance is not reachable.
+ */
+abstract class E2ETestCase extends TestCase {
+
+    protected static string $baseUrl;
+    protected static string $adminUser;
+    protected static string $adminPassword;
+
+    /** @var list<string> WebDAV paths (relative to the admin files root) to delete after the class */
+    protected static array $cleanupPaths = [];
+
+    public static function setUpBeforeClass(): void {
+        self::$baseUrl = rtrim(getenv('NEXTCLOUD_E2E_BASE_URL') ?: 'http://localhost:8088', '/');
+        self::$adminUser = getenv('NEXTCLOUD_E2E_ADMIN_USER') ?: 'admin';
+        self::$adminPassword = getenv('NEXTCLOUD_E2E_ADMIN_PASSWORD') ?: 'admin';
+
+        try {
+            $status = (new Client(['timeout' => 5]))->get(self::$baseUrl . '/status.php');
+            $body = (string)$status->getBody();
+            if ($status->getStatusCode() !== 200 || !str_contains($body, '"installed":true')) {
+                self::markTestSkipped('Nextcloud e2e instance is not installed at ' . self::$baseUrl);
+            }
+        } catch (\Throwable $e) {
+            self::markTestSkipped('Nextcloud e2e instance is not reachable at ' . self::$baseUrl . ': ' . $e->getMessage());
+        }
+
+        // Pin the admin language so message assertions are deterministic
+        self::apiClient()->put('/ocs/v2.php/cloud/users/' . self::$adminUser, [
+            'form_params' => ['key' => 'language', 'value' => 'en'],
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void {
+        foreach (self::$cleanupPaths as $path) {
+            try {
+                self::apiClient()->delete('/remote.php/dav/files/' . self::$adminUser . '/' . ltrim($path, '/'));
+            } catch (\Throwable $e) {
+                // best effort cleanup
+            }
+        }
+        self::$cleanupPaths = [];
+    }
+
+    /**
+     * Cookie-less API client authenticated as admin. The OCS-APIRequest
+     * header marks the request as an API request, which is how non-browser
+     * clients pass the CSRF checks on both OCS and app routes.
+     */
+    protected static function apiClient(): Client {
+        return new Client([
+            'base_uri' => self::$baseUrl,
+            'auth' => [self::$adminUser, self::$adminPassword],
+            'headers' => [
+                'OCS-APIRequest' => 'true',
+                'Accept' => 'application/json',
+            ],
+            'http_errors' => false,
+            'timeout' => 30,
+        ]);
+    }
+
+    /**
+     * Browser-like anonymous client: keeps cookies, sends no auth and no
+     * OCS header, so it is subject to the same CSRF/session rules as a
+     * real visitor.
+     */
+    protected static function browserClient(CookieJar $jar): Client {
+        return new Client([
+            'base_uri' => self::$baseUrl,
+            'cookies' => $jar,
+            'http_errors' => false,
+            'timeout' => 30,
+            'allow_redirects' => true,
+        ]);
+    }
+
+    protected static function extractRequestToken(string $html): string {
+        if (!preg_match('/data-requesttoken="([^"]+)"/', $html, $matches)) {
+            self::fail('No requesttoken found in page');
+        }
+        return html_entity_decode($matches[1], ENT_QUOTES);
+    }
+
+    protected static function davPut(string $path, string $content): int {
+        self::$cleanupPaths[] = $path;
+        $response = self::apiClient()->put(
+            '/remote.php/dav/files/' . self::$adminUser . '/' . ltrim($path, '/'),
+            ['body' => $content]
+        );
+        return $response->getStatusCode();
+    }
+
+    /**
+     * @return array{fileid: int, contenttype: string}
+     */
+    protected static function davStat(string $path): array {
+        $response = self::apiClient()->request('PROPFIND',
+            '/remote.php/dav/files/' . self::$adminUser . '/' . ltrim($path, '/'),
+            [
+                'headers' => ['Depth' => '0', 'Content-Type' => 'application/xml'],
+                'body' => '<?xml version="1.0"?>
+                    <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+                        <d:prop><oc:fileid/><d:getcontenttype/></d:prop>
+                    </d:propfind>',
+            ]
+        );
+        self::assertSame(207, $response->getStatusCode(), 'PROPFIND ' . $path . ' failed');
+
+        $body = (string)$response->getBody();
+        preg_match('#<oc:fileid>(\d+)</oc:fileid>#', $body, $fileId);
+        preg_match('#<d:getcontenttype>([^<]*)</d:getcontenttype>#', $body, $contentType);
+
+        return [
+            'fileid' => (int)($fileId[1] ?? 0),
+            'contenttype' => $contentType[1] ?? '',
+        ];
+    }
+
+    protected static function decodeJson(string $body): array {
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded, 'Expected JSON response, got: ' . substr($body, 0, 200));
+        return $decoded;
+    }
+}

--- a/tests/e2e/E2ETestCase.php
+++ b/tests/e2e/E2ETestCase.php
@@ -42,10 +42,40 @@ abstract class E2ETestCase extends TestCase {
             self::markTestSkipped('Nextcloud e2e instance is not reachable at ' . self::$baseUrl . ': ' . $e->getMessage());
         }
 
+        self::assertAppIsServed();
+
         // Pin the admin language so message assertions are deterministic
         self::apiClient()->put('/ocs/v2.php/cloud/users/' . self::$adminUser, [
             'form_params' => ['key' => 'language', 'value' => 'en'],
         ]);
+    }
+
+    /**
+     * The instance is up, but is it actually serving this app?
+     *
+     * Nextcloud answers 404 on the app routes when the app is not enabled for
+     * the user, and the web server can lag behind an "occ app:enable" because
+     * the enabled apps are cached in APCu, which occ does not share. Checking
+     * once here turns that into one clear message instead of every test in the
+     * suite failing with an unexplained 404.
+     */
+    private static function assertAppIsServed(): void {
+        $response = self::apiClient()->get('/index.php/apps/drawio/edit', [
+            'query' => ['fileId' => 1],
+            'headers' => ['Accept' => 'text/html'],
+        ]);
+
+        if ($response->getStatusCode() === 200 && str_contains((string)$response->getBody(), 'iframeEditor')) {
+            return;
+        }
+
+        self::fail(sprintf(
+            'The drawio app is not served at %s (HTTP %d for /apps/drawio/edit). '
+            . 'Enable it with "occ app:enable drawio"; if it was just enabled, the web server may still '
+            . 'have the previous app list cached in APCu and needs a restart.',
+            self::$baseUrl,
+            $response->getStatusCode()
+        ));
     }
 
     public static function tearDownAfterClass(): void {

--- a/tests/e2e/EditorApiE2eTest.php
+++ b/tests/e2e/EditorApiE2eTest.php
@@ -37,7 +37,16 @@ final class EditorApiE2eTest extends E2ETestCase {
         $this->assertNotEmpty($data['instanceId']);
     }
 
-    public function testLoadSaveRoundTripWithEtagRotation(): void {
+    /**
+     * The contract the editor depends on: a save persists the content and hands
+     * back the ETag the file now has, so the next save is not rejected.
+     *
+     * Do not assert that the ETag differs from the previous one. Nextcloud
+     * derives it from the file metadata, which on some filesystems is identical
+     * for two writes within the same second, so that assertion fails depending
+     * on how fast the machine is rather than on this app being correct.
+     */
+    public function testLoadSaveRoundTripReturnsTheCurrentEtag(): void {
         $load = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
             'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
         ])->getBody());
@@ -53,7 +62,7 @@ final class EditorApiE2eTest extends E2ETestCase {
         ]);
         $this->assertSame(200, $save->getStatusCode());
         $saveData = self::decodeJson((string)$save->getBody());
-        $this->assertNotSame($load['etag'], $saveData['etag']);
+        $this->assertNotEmpty($saveData['etag']);
 
         $reload = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
             'query' => ['fileId' => self::$fileId, 'shareToken' => ''],

--- a/tests/e2e/EditorApiE2eTest.php
+++ b/tests/e2e/EditorApiE2eTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Drawio\Tests\E2e;
+
+/**
+ * End-to-end tests of the editor backend over HTTP: load/save round trip,
+ * optimistic concurrency, previews, versions and the editor page itself.
+ */
+final class EditorApiE2eTest extends E2ETestCase {
+
+    private static string $fileName;
+    private static int $fileId;
+
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        self::$fileName = 'E2E-editor-' . uniqid() . '.drawio';
+        self::davPut(self::$fileName, '<mxfile>initial</mxfile>');
+        self::$fileId = self::davStat(self::$fileName)['fileid'];
+    }
+
+    public function testGetFileInfoReturnsMetadata(): void {
+        $response = self::apiClient()->get('/index.php/apps/drawio/ajax/getFileInfo', [
+            'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = self::decodeJson((string)$response->getBody());
+        $this->assertSame(self::$fileId, $data['id']);
+        $this->assertSame(self::$fileName, $data['name']);
+        $this->assertSame('application/x-drawio', $data['mime']);
+        $this->assertTrue($data['writeable']);
+        $this->assertTrue($data['versionsEnabled']);
+        $this->assertNotEmpty($data['etag']);
+        $this->assertNotEmpty($data['instanceId']);
+    }
+
+    public function testLoadSaveRoundTripWithEtagRotation(): void {
+        $load = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
+        ])->getBody());
+        $this->assertSame('<mxfile>initial</mxfile>', $load['xml']);
+
+        $save = self::apiClient()->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => (string)self::$fileId,
+                'shareToken' => '',
+                'fileContents' => '<mxfile>version-2</mxfile>',
+                'etag' => $load['etag'],
+            ],
+        ]);
+        $this->assertSame(200, $save->getStatusCode());
+        $saveData = self::decodeJson((string)$save->getBody());
+        $this->assertNotSame($load['etag'], $saveData['etag']);
+
+        $reload = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
+        ])->getBody());
+        $this->assertSame('<mxfile>version-2</mxfile>', $reload['xml']);
+        $this->assertSame($saveData['etag'], $reload['etag']);
+    }
+
+    public function testSaveWithStaleEtagIsRejectedWithConflict(): void {
+        $response = self::apiClient()->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => (string)self::$fileId,
+                'shareToken' => '',
+                'fileContents' => '<mxfile>must-not-win</mxfile>',
+                'etag' => 'stale-etag-deadbeef',
+            ],
+        ]);
+
+        $this->assertSame(409, $response->getStatusCode());
+
+        $reload = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
+        ])->getBody());
+        $this->assertStringNotContainsString('must-not-win', $reload['xml']);
+    }
+
+    public function testSaveWithoutEtagComplainsAboutEtag(): void {
+        $response = self::apiClient()->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => (string)self::$fileId,
+                'shareToken' => '',
+                'fileContents' => '<mxfile>x</mxfile>',
+                'etag' => '',
+            ],
+        ]);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('File etag not supplied', self::decodeJson((string)$response->getBody())['message']);
+    }
+
+    public function testSavePreviewMakesServerPreviewAvailable(): void {
+        // 1x1 red PNG
+        $png = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+
+        $response = self::apiClient()->post('/index.php/apps/drawio/ajax/savePreview', [
+            'json' => [
+                'fileId' => (string)self::$fileId,
+                'shareToken' => '',
+                'previewContents' => base64_encode($png),
+            ],
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $preview = self::apiClient()->get('/index.php/core/preview', [
+            'query' => ['fileId' => self::$fileId, 'x' => 64, 'y' => 64, 'a' => 'true'],
+            'headers' => ['Accept' => 'image/*'],
+        ]);
+        $this->assertSame(200, $preview->getStatusCode());
+        $this->assertStringContainsString('image/png', $preview->getHeaderLine('Content-Type'));
+    }
+
+    public function testFileRevisionsAreListedAndLoadable(): void {
+        // Ensure at least one more write so a version of the previous content exists
+        $load = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => self::$fileId, 'shareToken' => ''],
+        ])->getBody());
+        self::apiClient()->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => (string)self::$fileId,
+                'shareToken' => '',
+                'fileContents' => '<mxfile>version-3</mxfile>',
+                'etag' => $load['etag'],
+            ],
+        ]);
+
+        $revisions = self::apiClient()->get('/index.php/apps/drawio/ajax/getFileRevisions', [
+            'query' => ['fileId' => self::$fileId],
+        ]);
+        $this->assertSame(200, $revisions->getStatusCode());
+        $list = self::decodeJson((string)$revisions->getBody());
+
+        $this->assertNotEmpty($list, 'Expected at least one file version after multiple saves');
+        $this->assertArrayHasKey('revId', $list[0]);
+        $this->assertArrayHasKey('timestamp', $list[0]);
+
+        $version = self::apiClient()->get('/index.php/apps/drawio/ajax/loadFileVersion', [
+            'query' => ['fileId' => self::$fileId, 'revId' => $list[0]['revId']],
+        ]);
+        $this->assertSame(200, $version->getStatusCode());
+        // The version content is returned as a JSON-encoded string
+        $content = json_decode((string)$version->getBody());
+        $this->assertIsString($content);
+        $this->assertStringContainsString('<mxfile>', $content);
+    }
+
+    public function testEditorPageRendersWithDrawioCsp(): void {
+        $response = self::apiClient()->get('/index.php/apps/drawio/edit', [
+            'query' => ['fileId' => self::$fileId, 'isWB' => 'false'],
+            'headers' => ['Accept' => 'text/html'],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $html = (string)$response->getBody();
+        $this->assertStringContainsString('iframeEditor', $html);
+        $this->assertStringContainsString('drawioData', $html);
+
+        $csp = $response->getHeaderLine('Content-Security-Policy');
+        $this->assertMatchesRegularExpression('#frame-src[^;]*https://embed\.diagrams\.net#', $csp);
+        $this->assertMatchesRegularExpression('#frame-src[^;]*blob:#', $csp);
+        $this->assertMatchesRegularExpression('#worker-src[^;]*https://embed\.diagrams\.net#', $csp);
+        $this->assertMatchesRegularExpression('#worker-src[^;]*blob:#', $csp);
+        $this->assertMatchesRegularExpression('#script-src[^;]*https://embed\.diagrams\.net#', $csp);
+    }
+
+    public function testCreateEndpointCreatesEmptyDiagram(): void {
+        $rootId = self::davStat('')['fileid'];
+        $name = 'E2E-create-' . uniqid() . '.drawio';
+        self::$cleanupPaths[] = $name;
+
+        $response = self::apiClient()->post('/index.php/apps/drawio/ajax/new', [
+            'json' => ['name' => $name, 'dirId' => (string)$rootId, 'shareToken' => ''],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = self::decodeJson((string)$response->getBody());
+        $this->assertArrayNotHasKey('error', $data);
+        $this->assertSame($name, $data['name']);
+        $this->assertSame('application/x-drawio', $data['mimetype']);
+        $this->assertGreaterThan(0, $data['id']);
+    }
+}

--- a/tests/e2e/MimeTypeE2eTest.php
+++ b/tests/e2e/MimeTypeE2eTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Drawio\Tests\E2e;
+
+/**
+ * End-to-end proof of the MIME registration chain: files uploaded through
+ * WebDAV must be detected as draw.io types by the server (config
+ * mimetypemapping.json written by the repair step + runtime registration).
+ */
+final class MimeTypeE2eTest extends E2ETestCase {
+
+    public function testUploadedDrawioFileGetsDrawioMimeType(): void {
+        $name = 'E2E-mime-' . uniqid() . '.drawio';
+
+        $status = self::davPut($name, '<mxfile><diagram id="a" name="P1"/></mxfile>');
+        $this->assertContains($status, [201, 204]);
+
+        $stat = self::davStat($name);
+        $this->assertSame('application/x-drawio', $stat['contenttype']);
+        $this->assertGreaterThan(0, $stat['fileid']);
+    }
+
+    public function testUploadedWhiteboardFileGetsWhiteboardMimeType(): void {
+        $name = 'E2E-mime-' . uniqid() . '.dwb';
+
+        $status = self::davPut($name, '<mxfile><diagram id="a" name="P1"/></mxfile>');
+        $this->assertContains($status, [201, 204]);
+
+        $this->assertSame('application/x-drawio-wb', self::davStat($name)['contenttype']);
+    }
+
+    public function testTemplateApiCreatesFileWithDrawioMimeType(): void {
+        $name = 'E2E-template-' . uniqid() . '.drawio';
+        self::$cleanupPaths[] = $name;
+
+        $response = self::apiClient()->post('/ocs/v2.php/apps/files/api/v1/templates/create?format=json', [
+            'json' => ['filePath' => '/' . $name, 'templatePath' => '', 'templateType' => 'user'],
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = self::decodeJson((string)$response->getBody())['ocs']['data'];
+        $this->assertSame('application/x-drawio', $data['mime']);
+        $this->assertGreaterThan(0, $data['fileid']);
+    }
+}

--- a/tests/e2e/PublicShareE2eTest.php
+++ b/tests/e2e/PublicShareE2eTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Drawio\Tests\E2e;
+
+use GuzzleHttp\Cookie\CookieJar;
+
+/**
+ * End-to-end tests of the public share flow, including the Nextcloud 33
+ * share password session mechanism (public_link_authenticated_frontend):
+ * anonymous visitors must be rejected before entering the share password
+ * and accepted afterwards.
+ */
+final class PublicShareE2eTest extends E2ETestCase {
+
+    private const SHARE_PASSWORD = 'Fixture#2026!drawio';
+
+    private static string $fileName;
+    private static int $shareId;
+    private static string $shareToken;
+
+    public static function setUpBeforeClass(): void {
+        parent::setUpBeforeClass();
+
+        self::$fileName = 'E2E-share-' . uniqid() . '.drawio';
+        self::davPut(self::$fileName, '<mxfile>shared-content</mxfile>');
+
+        $response = self::apiClient()->post('/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json', [
+            'json' => [
+                'path' => '/' . self::$fileName,
+                'shareType' => 3,
+                'password' => self::SHARE_PASSWORD,
+            ],
+        ]);
+        if ($response->getStatusCode() !== 200) {
+            self::fail('Could not create password protected share: ' . $response->getBody());
+        }
+        $data = json_decode((string)$response->getBody(), true)['ocs']['data'];
+        self::$shareId = (int)$data['id'];
+        self::$shareToken = (string)$data['token'];
+    }
+
+    /**
+     * @return array{jar: CookieJar, token: string, authUrl: string}
+     */
+    private function openShareAuthPage(): array {
+        $jar = new CookieJar();
+        $response = self::browserClient($jar)->get('/index.php/s/' . self::$shareToken, [
+            'allow_redirects' => ['track_redirects' => true],
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $html = (string)$response->getBody();
+        $this->assertStringContainsString('core-public-share-auth', $html,
+            'Share page should show the password prompt');
+
+        // The auth page (GET) and the authenticate endpoint (POST) share the
+        // same URL, so the last redirect target is where the password form posts to.
+        $redirects = $response->getHeader('X-Guzzle-Redirect-History');
+        $authUrl = $redirects === [] ? ('/index.php/s/' . self::$shareToken) : end($redirects);
+
+        return [
+            'jar' => $jar,
+            'token' => self::extractRequestToken($html),
+            'authUrl' => $authUrl,
+        ];
+    }
+
+    private function authenticate(array $session, string $password): void {
+        $response = self::browserClient($session['jar'])->post($session['authUrl'], [
+            'form_params' => [
+                'password' => $password,
+                'requesttoken' => $session['token'],
+            ],
+        ]);
+        $this->assertContains($response->getStatusCode(), [200, 303]);
+    }
+
+    private function getFileInfoAnonymously(array $session): \Psr\Http\Message\ResponseInterface {
+        return self::browserClient($session['jar'])->get('/index.php/apps/drawio/ajax/getFileInfo', [
+            'query' => ['fileId' => '', 'shareToken' => self::$shareToken],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ]);
+    }
+
+    public function testAnonymousAccessIsDeniedBeforePasswordEntry(): void {
+        $session = $this->openShareAuthPage();
+
+        $response = $this->getFileInfoAnonymously($session);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testWrongPasswordDoesNotAuthenticate(): void {
+        $session = $this->openShareAuthPage();
+
+        $this->authenticate($session, 'definitely-wrong-password');
+
+        $this->assertSame(403, $this->getFileInfoAnonymously($session)->getStatusCode());
+    }
+
+    public function testCorrectPasswordGrantsReadOnlyAccess(): void {
+        $session = $this->openShareAuthPage();
+        $this->authenticate($session, self::SHARE_PASSWORD);
+
+        $info = $this->getFileInfoAnonymously($session);
+        $this->assertSame(200, $info->getStatusCode());
+        $data = self::decodeJson((string)$info->getBody());
+        $this->assertSame(self::$fileName, $data['name']);
+        $this->assertFalse($data['writeable']);
+        $this->assertFalse($data['versionsEnabled']);
+
+        $load = self::browserClient($session['jar'])->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => '', 'shareToken' => self::$shareToken],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ]);
+        $this->assertSame(200, $load->getStatusCode());
+        $this->assertSame('<mxfile>shared-content</mxfile>', self::decodeJson((string)$load->getBody())['xml']);
+    }
+
+    public function testSaveThroughReadOnlyShareIsForbidden(): void {
+        $session = $this->openShareAuthPage();
+        $this->authenticate($session, self::SHARE_PASSWORD);
+
+        $load = self::decodeJson((string)self::browserClient($session['jar'])->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => '', 'shareToken' => self::$shareToken],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ])->getBody());
+
+        $save = self::browserClient($session['jar'])->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => '',
+                'shareToken' => self::$shareToken,
+                'fileContents' => '<mxfile>anonymous-write</mxfile>',
+                'etag' => $load['etag'],
+            ],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ]);
+
+        $this->assertSame(403, $save->getStatusCode());
+    }
+
+    public function testEditableShareAllowsAnonymousSave(): void {
+        $update = self::apiClient()->put('/ocs/v2.php/apps/files_sharing/api/v1/shares/' . self::$shareId . '?format=json', [
+            'json' => ['permissions' => 3], // read + update
+        ]);
+        $this->assertSame(200, $update->getStatusCode());
+
+        $session = $this->openShareAuthPage();
+        $this->authenticate($session, self::SHARE_PASSWORD);
+
+        $load = self::decodeJson((string)self::browserClient($session['jar'])->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => '', 'shareToken' => self::$shareToken],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ])->getBody());
+        $this->assertTrue($load['writeable']);
+
+        $save = self::browserClient($session['jar'])->put('/index.php/apps/drawio/ajax/save', [
+            'json' => [
+                'fileId' => '',
+                'shareToken' => self::$shareToken,
+                'fileContents' => '<mxfile>anonymous-edit</mxfile>',
+                'etag' => $load['etag'],
+            ],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ]);
+        $this->assertSame(200, $save->getStatusCode());
+
+        $verify = self::decodeJson((string)self::apiClient()->get('/index.php/apps/drawio/ajax/load', [
+            'query' => ['fileId' => self::davStat(self::$fileName)['fileid'], 'shareToken' => ''],
+        ])->getBody());
+        $this->assertSame('<mxfile>anonymous-edit</mxfile>', $verify['xml']);
+    }
+
+    public function testUnknownShareTokenIsNotFound(): void {
+        $response = self::apiClient()->get('/index.php/apps/drawio/ajax/getFileInfo', [
+            'query' => ['fileId' => '', 'shareToken' => 'doesnotexist' . uniqid()],
+        ]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+}

--- a/tests/e2e/SettingsAndTemplatesE2eTest.php
+++ b/tests/e2e/SettingsAndTemplatesE2eTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Drawio\Tests\E2e;
+
+/**
+ * End-to-end tests of the admin settings endpoint and its effect on the
+ * "+" new file menu (template creators), including the whiteboards toggle.
+ */
+final class SettingsAndTemplatesE2eTest extends E2ETestCase {
+
+    private static function postSettings(string $whiteboards): array {
+        $response = self::apiClient()->post('/index.php/apps/drawio/ajax/settings', [
+            'form_params' => [
+                'drawioUrl' => '',
+                'offlineMode' => 'no',
+                'theme' => 'kennedy',
+                'lang' => 'auto',
+                'autosave' => 'yes',
+                'libraries' => 'no',
+                'darkMode' => 'auto',
+                'previews' => 'yes',
+                'drawioConfig' => '',
+                'whiteboards' => $whiteboards,
+            ],
+        ]);
+        self::assertSame(200, $response->getStatusCode(), 'settings save failed: ' . $response->getBody());
+        return self::decodeJson((string)$response->getBody());
+    }
+
+    /**
+     * @return list<string> action labels of the drawio template creators
+     */
+    private static function drawioTemplateCreatorLabels(): array {
+        $response = self::apiClient()->get('/ocs/v2.php/apps/files/api/v1/templates?format=json');
+        self::assertSame(200, $response->getStatusCode());
+
+        $creators = self::decodeJson((string)$response->getBody())['ocs']['data'];
+        $labels = [];
+        foreach ($creators as $creator) {
+            if (($creator['app'] ?? '') === 'drawio') {
+                $labels[] = $creator['actionLabel'];
+            }
+        }
+        return $labels;
+    }
+
+    public static function tearDownAfterClass(): void {
+        // Safety net: restore defaults even if a test failed midway
+        try {
+            self::postSettings('yes');
+        } catch (\Throwable $e) {
+        }
+        parent::tearDownAfterClass();
+    }
+
+    public function testSettingsRoundTripEchoesPersistedValues(): void {
+        $result = self::postSettings('yes');
+
+        $this->assertSame('https://embed.diagrams.net', $result['drawioUrl']);
+        $this->assertSame('kennedy', $result['theme']);
+        $this->assertSame('no', $result['offlineMode']);
+        $this->assertSame('yes', $result['drawioAutosave']);
+        $this->assertSame('{}', $result['drawioConfig']);
+        $this->assertSame('yes', $result['drawioWhiteboards']);
+    }
+
+    public function testWhiteboardsToggleControlsNewFileMenuEntries(): void {
+        self::postSettings('yes');
+        $labels = self::drawioTemplateCreatorLabels();
+        $this->assertContains('New Diagram', $labels);
+        $this->assertContains('New Whiteboard', $labels);
+
+        self::postSettings('no');
+        $labels = self::drawioTemplateCreatorLabels();
+        $this->assertContains('New Diagram', $labels);
+        $this->assertNotContains('New Whiteboard', $labels,
+            'Disabling whiteboards must remove the New Whiteboard template creator');
+
+        self::postSettings('yes');
+        $this->assertContains('New Whiteboard', self::drawioTemplateCreatorLabels());
+    }
+}


### PR DESCRIPTION
## Summary

Add an end-to-end suite against a running Nextcloud, useful for development tasks.

## Testing

- [x] Tested against the [test checklist](../blob/main/DEV.md#test-checklist) (relevant sections)
- [x] Ran `npm run build` successfully