### PR TITLE
Fix occ integrity:check-core errors left by app versions <= 4.2.5

### DIFF
--- a/lib/Migration/MimeTypeMigration.php
+++ b/lib/Migration/MimeTypeMigration.php
@@ -2,14 +2,16 @@
 namespace OCA\Drawio\Migration;
 
 /**
- * NOTE: This class and its subclasses use \OC::$configDir, for which there is
- * no public OCP API. Registering custom MIME types via config/mimetypemapping.json
- * is the approach recommended by the Nextcloud documentation and shared by other
- * apps (Keeweb, Mind Map). These usages should be reviewed if Nextcloud provides
- * a public MIME type registration API (https://github.com/nextcloud/server/issues/9192).
+ * NOTE: This class and its subclasses use \OC::$configDir and \OC::$SERVERROOT,
+ * for which there is no public OCP API. Registering custom MIME types via
+ * config/mimetypemapping.json is the approach recommended by the Nextcloud
+ * documentation and shared by other apps (Keeweb, Mind Map). These usages
+ * should be reviewed if Nextcloud provides a public MIME type registration API
+ * (https://github.com/nextcloud/server/issues/10131).
  **/
 
 use OCP\Files\IMimeTypeLoader;
+use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 abstract class MimeTypeMigration implements IRepairStep
@@ -17,7 +19,96 @@ abstract class MimeTypeMigration implements IRepairStep
     const CUSTOM_MIMETYPEMAPPING = 'mimetypemapping.json';
     const CUSTOM_MIMETYPEALIASES = 'mimetypealiases.json';
 
+    // File type icons that app versions up to 4.2.x copied into the Nextcloud
+    // core, where the code integrity check reports them as EXTRA_FILE
+    // (https://github.com/jgraph/drawio-nextcloud/issues/70).
+    const LEGACY_CORE_ICONS = ['drawio.svg', 'dwb.svg'];
+
+    // MIME type aliases those versions registered so the icons above were used.
+    // The app no longer ships those icons, so the aliases have no effect - but
+    // they would be baked back into core/js/mimetypelist.js by the next
+    // "occ maintenance:mimetype:update-js" run and break the integrity check.
+    const LEGACY_ALIASES = [
+        'application/x-drawio' => 'drawio',
+        'application/x-drawio-wb' => 'dwb'
+    ];
+
     public function __construct(protected IMimeTypeLoader $mimeTypeLoader)
     {
+    }
+
+    /**
+     * Delete the file type icons older versions of this app copied into the
+     * Nextcloud core directory.
+     */
+    protected function removeLegacyCoreIcons(IOutput $output): void
+    {
+        foreach (self::LEGACY_CORE_ICONS as $icon) {
+            $path = \OC::$SERVERROOT . '/core/img/filetypes/' . $icon;
+
+            if (!file_exists($path)) {
+                continue;
+            }
+
+            if (@unlink($path)) {
+                $output->info('Removed ' . $path . ', which an older version of this app copied into the Nextcloud core');
+            } else {
+                $output->warning('Could not remove ' . $path . '. Delete it manually to fix the code integrity check.');
+            }
+        }
+    }
+
+    /**
+     * Merge the given entries into a MIME type configuration file, keeping the
+     * entries other apps have registered.
+     */
+    protected function appendToFile(string $filename, array $data): void
+    {
+        $config = $this->readFile($filename);
+
+        foreach ($data as $key => $value) {
+            $config[$key] = $value;
+        }
+
+        $this->writeFile($filename, $config);
+    }
+
+    /**
+     * Remove the given entries from a MIME type configuration file, keeping the
+     * entries other apps have registered.
+     */
+    protected function removeFromFile(string $filename, array $data): void
+    {
+        if (!file_exists($filename)) {
+            return;
+        }
+
+        $config = $this->readFile($filename);
+
+        foreach (array_keys($data) as $key) {
+            unset($config[$key]);
+        }
+
+        $this->writeFile($filename, $config);
+    }
+
+    private function readFile(string $filename): array
+    {
+        if (!file_exists($filename)) {
+            return [];
+        }
+
+        $config = json_decode((string)file_get_contents($filename), true);
+
+        return is_array($config) ? $config : [];
+    }
+
+    private function writeFile(string $filename, array $config): void
+    {
+        // An empty array would be encoded as "[]", but Nextcloud expects these
+        // files to hold a JSON object.
+        $data = $config === [] ? new \stdClass() : $config;
+
+        file_put_contents($filename, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -1,10 +1,26 @@
 <?php
 namespace OCA\Drawio\Migration;
 
+use OCA\Drawio\AppInfo\Application;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 
 class RegisterMimeType extends MimeTypeMigration
 {
+    // Set once the leftovers of app versions up to 4.2.x have been removed, so
+    // that an administrator who deliberately restores the core icons and
+    // aliases afterwards keeps them.
+    const CLEANUP_FLAG = 'LegacyCoreCleanupDone';
+
+    public function __construct(
+        IMimeTypeLoader $mimeTypeLoader,
+        private IAppConfig $appConfig
+    )
+    {
+        parent::__construct($mimeTypeLoader);
+    }
+
     public function getName(): string
     {
         return 'Register MIME types for Diagramming';
@@ -21,18 +37,36 @@ class RegisterMimeType extends MimeTypeMigration
 
     private function registerForNewFiles(): void
     {
-        $configDir = \OC::$configDir;
-        $mimetypealiasesFile = $configDir . self::CUSTOM_MIMETYPEALIASES;
-        $mimetypemappingFile = $configDir . self::CUSTOM_MIMETYPEMAPPING;
-
-        $this->appendToFile($mimetypealiasesFile, [
-            'application/x-drawio' => 'drawio',
-            'application/x-drawio-wb' => 'dwb'
-        ]);
-        $this->appendToFile($mimetypemappingFile, [
+        // Only the extension to MIME type mapping is registered. The icon
+        // aliases are deliberately not written: the app does not ship icons into
+        // the Nextcloud core anymore, so they would have no effect other than
+        // breaking the code integrity check when core/js/mimetypelist.js is
+        // regenerated.
+        $this->appendToFile(\OC::$configDir . self::CUSTOM_MIMETYPEMAPPING, [
             'drawio' => ['application/x-drawio'],
             'dwb' => ['application/x-drawio-wb']
         ]);
+    }
+
+    /**
+     * Undo what app versions up to 4.2.x changed outside of this app, which
+     * makes "occ integrity:check-core" report EXTRA_FILE for the icons. Runs
+     * once per instance.
+     *
+     * core/js/mimetypelist.js cannot be repaired from here: its original
+     * content is only known to the Nextcloud release, so restoring it stays a
+     * manual step for the administrator.
+     */
+    private function cleanUpLegacyCoreChanges(IOutput $output): void
+    {
+        if ($this->appConfig->getValueString(Application::APP_ID, self::CLEANUP_FLAG) === 'yes') {
+            return;
+        }
+
+        $this->removeLegacyCoreIcons($output);
+        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEALIASES, self::LEGACY_ALIASES);
+
+        $this->appConfig->setValueString(Application::APP_ID, self::CLEANUP_FLAG, 'yes');
     }
 
     public function run(IOutput $output): void
@@ -45,19 +79,9 @@ class RegisterMimeType extends MimeTypeMigration
         // Register the mime type for new files
         $this->registerForNewFiles();
 
-        $output->info('The mimetype was successfully registered.');
-    }
+        // Clean up what older versions changed in the Nextcloud core
+        $this->cleanUpLegacyCoreChanges($output);
 
-    private function appendToFile(string $filename, array $data): void
-    {
-        $obj = [];
-        if (file_exists($filename)) {
-            $content = file_get_contents($filename);
-            $obj = json_decode($content, true);
-        }
-        foreach ($data as $key => $value) {
-            $obj[$key] = $value;
-        }
-        file_put_contents($filename, json_encode($obj,  JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+        $output->info('The mimetype was successfully registered.');
     }
 }

--- a/lib/Migration/UnregisterMimeType.php
+++ b/lib/Migration/UnregisterMimeType.php
@@ -5,55 +5,42 @@ use OCP\Migration\IOutput;
 
 class UnregisterMimeType extends MimeTypeMigration
 {
-    public function getName()
+    public function getName(): string
     {
         return 'Unregister MIME type for Diagramming';
     }
 
-    private function unregisterForExistingFiles()
+    private function unregisterForExistingFiles(): void
     {
         $mimeTypeId = $this->mimeTypeLoader->getId('application/octet-stream');
         $this->mimeTypeLoader->updateFilecache('drawio', $mimeTypeId);
         $this->mimeTypeLoader->updateFilecache('dwb', $mimeTypeId);
     }
 
-    private function unregisterForNewFiles()
+    private function unregisterForNewFiles(): void
     {
-        $configDir = \OC::$configDir;
-        $mimetypealiasesFile = $configDir . self::CUSTOM_MIMETYPEALIASES;
-        $mimetypemappingFile = $configDir . self::CUSTOM_MIMETYPEMAPPING;
-
-        $this->removeFromFile($mimetypealiasesFile, [
-            'application/x-drawio' => 'drawio',
-            'application/x-drawio-wb' => 'dwb'
-        ]);
-        $this->removeFromFile($mimetypemappingFile, [
+        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEMAPPING, [
             'drawio' => ['application/x-drawio'],
-            'dwb' => ['application/x-drawio-wb']]);
+            'dwb' => ['application/x-drawio-wb']
+        ]);
+
+        // Written by app versions up to 4.2.x
+        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEALIASES, self::LEGACY_ALIASES);
     }
 
-    public function run(IOutput $output)
+    public function run(IOutput $output): void
     {
         $output->info('Unregistering the mimetype...');
 
-        // Register the mime type for existing files
+        // Reset existing files to the generic MIME type
         $this->unregisterForExistingFiles();
 
-        // Register the mime type for new files
+        // Remove the MIME type registration for new files
         $this->unregisterForNewFiles();
 
-        $output->info('The mimetype was successfully unregistered.');
-    }
+        // Remove the icons older versions copied into the Nextcloud core
+        $this->removeLegacyCoreIcons($output);
 
-    private function removeFromFile(string $filename, array $data) {
-        $obj = [];
-        if (file_exists($filename)) {
-            $content = file_get_contents($filename);
-            $obj = json_decode($content, true);
-        }
-        foreach ($data as $key => $value) {
-            unset($obj[$key]);
-        }
-        file_put_contents($filename, json_encode($obj,  JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
+        $output->info('The mimetype was successfully unregistered.');
     }
 }

--- a/tests/unit/Migration/RegisterMimeTypeTest.php
+++ b/tests/unit/Migration/RegisterMimeTypeTest.php
@@ -6,42 +6,92 @@ namespace OCA\Drawio\Tests\Unit\Migration;
 
 use OCA\Drawio\Migration\RegisterMimeType;
 use OCP\Files\IMimeTypeLoader;
+use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class RegisterMimeTypeTest extends TestCase {
 
+    private string $root;
     private string $configDir;
+    private string $coreIconDir;
     private IMimeTypeLoader&MockObject $mimeTypeLoader;
 
+    /** @var array<string, string> */
+    private array $appValues = [];
+
     protected function setUp(): void {
-        $this->configDir = sys_get_temp_dir() . '/drawio-test-' . uniqid() . '/';
-        mkdir($this->configDir);
+        $this->root = sys_get_temp_dir() . '/drawio-test-' . uniqid();
+        $this->configDir = $this->root . '/config/';
+        $this->coreIconDir = $this->root . '/core/img/filetypes/';
+        mkdir($this->configDir, 0777, true);
+        mkdir($this->coreIconDir, 0777, true);
+
         \OC::$configDir = $this->configDir;
+        \OC::$SERVERROOT = $this->root;
 
         $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
-    }
-
-    protected function tearDown(): void {
-        foreach (['mimetypemapping.json', 'mimetypealiases.json'] as $file) {
-            @unlink($this->configDir . $file);
-        }
-        @rmdir($this->configDir);
-    }
-
-    private function runStep(): void {
-        $step = new RegisterMimeType($this->mimeTypeLoader);
-        $this->assertSame('Register MIME types for Diagramming', $step->getName());
-        $step->run($this->createMock(IOutput::class));
-    }
-
-    public function testRunWritesMimeTypeConfigFiles(): void {
         $this->mimeTypeLoader->method('getId')->willReturnMap([
             ['application/x-drawio', 7],
             ['application/x-drawio-wb', 8],
         ]);
+        $this->mimeTypeLoader->method('updateFilecache')->willReturn(1);
+
+        $this->appValues = [];
+    }
+
+    protected function tearDown(): void {
+        foreach (glob($this->configDir . '*') ?: [] as $file) {
+            unlink($file);
+        }
+        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
+            unlink($file);
+        }
+        foreach ([$this->configDir, $this->root . '/core/img/filetypes', $this->root . '/core/img', $this->root . '/core', $this->root] as $dir) {
+            @rmdir($dir);
+        }
+    }
+
+    private function createAppConfig(): IAppConfig&MockObject {
+        $appConfig = $this->createMock(IAppConfig::class);
+        $appConfig->method('getValueString')->willReturnCallback(
+            fn (string $app, string $key, string $default = '') => $this->appValues[$key] ?? $default
+        );
+        $appConfig->method('setValueString')->willReturnCallback(
+            function (string $app, string $key, string $value): bool {
+                $this->appValues[$key] = $value;
+                return true;
+            }
+        );
+        return $appConfig;
+    }
+
+    private function runStep(): void {
+        $step = new RegisterMimeType($this->mimeTypeLoader, $this->createAppConfig());
+        $this->assertSame('Register MIME types for Diagramming', $step->getName());
+        $step->run($this->createMock(IOutput::class));
+    }
+
+    private function writeLegacyIcons(): void {
+        file_put_contents($this->coreIconDir . 'drawio.svg', '<svg>old drawio</svg>');
+        file_put_contents($this->coreIconDir . 'dwb.svg', '<svg>old dwb</svg>');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readConfig(string $name): array {
+        return json_decode((string)file_get_contents($this->configDir . $name), true);
+    }
+
+    public function testRunWritesMimeTypeMapping(): void {
         $filecacheUpdates = [];
+        $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
+        $this->mimeTypeLoader->method('getId')->willReturnMap([
+            ['application/x-drawio', 7],
+            ['application/x-drawio-wb', 8],
+        ]);
         $this->mimeTypeLoader->expects($this->exactly(2))->method('updateFilecache')
             ->willReturnCallback(function (string $ext, int $mimeTypeId) use (&$filecacheUpdates): int {
                 $filecacheUpdates[$ext] = $mimeTypeId;
@@ -52,27 +102,104 @@ final class RegisterMimeTypeTest extends TestCase {
 
         $this->assertSame(['drawio' => 7, 'dwb' => 8], $filecacheUpdates);
 
-        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
+        $mapping = $this->readConfig('mimetypemapping.json');
         $this->assertSame(['application/x-drawio'], $mapping['drawio']);
         $this->assertSame(['application/x-drawio-wb'], $mapping['dwb']);
+    }
 
-        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
-        $this->assertSame('drawio', $aliases['application/x-drawio']);
-        $this->assertSame('dwb', $aliases['application/x-drawio-wb']);
+    /**
+     * Regression test: writing the icon aliases makes the next
+     * "occ maintenance:mimetype:update-js" bake them into
+     * core/js/mimetypelist.js, which breaks the code integrity check. The app
+     * does not ship the icons they refer to since 4.3.0.
+     */
+    public function testRunDoesNotWriteIconAliases(): void {
+        $this->runStep();
+
+        $this->assertFileDoesNotExist($this->configDir . 'mimetypealiases.json');
+    }
+
+    public function testRunRemovesAliasesWrittenByOlderVersions(): void {
+        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode([
+            'application/x-drawio' => 'drawio',
+            'application/x-drawio-wb' => 'dwb',
+            'application/x-mind' => 'mind',
+        ]));
+
+        $this->runStep();
+
+        $aliases = $this->readConfig('mimetypealiases.json');
+        $this->assertArrayNotHasKey('application/x-drawio', $aliases);
+        $this->assertArrayNotHasKey('application/x-drawio-wb', $aliases);
+        $this->assertSame('mind', $aliases['application/x-mind'], "Other apps' aliases must be kept");
+    }
+
+    public function testEmptiedAliasFileStaysAJsonObject(): void {
+        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode([
+            'application/x-drawio' => 'drawio',
+            'application/x-drawio-wb' => 'dwb',
+        ]));
+
+        $this->runStep();
+
+        $contents = trim((string)file_get_contents($this->configDir . 'mimetypealiases.json'));
+        $this->assertSame('{}', $contents, 'Nextcloud expects a JSON object, not an empty array');
+    }
+
+    /**
+     * Regression test for https://github.com/jgraph/drawio-nextcloud/issues/70:
+     * versions up to 4.2.x copied the file type icons into the Nextcloud core,
+     * where they are reported as EXTRA_FILE by "occ integrity:check-core".
+     */
+    public function testRunRemovesIconsCopiedIntoTheCoreByOlderVersions(): void {
+        $this->writeLegacyIcons();
+
+        $this->runStep();
+
+        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
+        $this->assertFileDoesNotExist($this->coreIconDir . 'dwb.svg');
+    }
+
+    public function testRunKeepsUnrelatedCoreIcons(): void {
+        file_put_contents($this->coreIconDir . 'text.svg', '<svg>text</svg>');
+
+        $this->runStep();
+
+        $this->assertFileExists($this->coreIconDir . 'text.svg');
+    }
+
+    public function testCleanupRunsOnlyOnce(): void {
+        $this->writeLegacyIcons();
+        $this->runStep();
+        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
+
+        // An administrator restoring the icons afterwards keeps them
+        $this->writeLegacyIcons();
+        $this->runStep();
+
+        $this->assertFileExists($this->coreIconDir . 'drawio.svg');
+        $this->assertFileExists($this->coreIconDir . 'dwb.svg');
     }
 
     public function testRunPreservesForeignEntriesInExistingConfigFiles(): void {
         file_put_contents($this->configDir . 'mimetypemapping.json', json_encode(['mind' => ['application/x-mind']]));
-        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode(['application/x-mind' => 'mind']));
 
         $this->runStep();
 
-        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
+        $mapping = $this->readConfig('mimetypemapping.json');
         $this->assertSame(['application/x-mind'], $mapping['mind']);
         $this->assertSame(['application/x-drawio'], $mapping['drawio']);
+    }
 
-        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
-        $this->assertSame('mind', $aliases['application/x-mind']);
-        $this->assertSame('drawio', $aliases['application/x-drawio']);
+    public function testRunSucceedsWhenCoreIconsAreNotWritable(): void {
+        // No icons and no core directory at all must not fail the upgrade
+        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->coreIconDir);
+
+        $this->runStep();
+
+        $this->assertFileExists($this->configDir . 'mimetypemapping.json');
     }
 }

--- a/tests/unit/Migration/UnregisterMimeTypeTest.php
+++ b/tests/unit/Migration/UnregisterMimeTypeTest.php
@@ -12,22 +12,40 @@ use PHPUnit\Framework\TestCase;
 
 final class UnregisterMimeTypeTest extends TestCase {
 
+    private string $root;
     private string $configDir;
+    private string $coreIconDir;
     private IMimeTypeLoader&MockObject $mimeTypeLoader;
 
     protected function setUp(): void {
-        $this->configDir = sys_get_temp_dir() . '/drawio-test-' . uniqid() . '/';
-        mkdir($this->configDir);
+        $this->root = sys_get_temp_dir() . '/drawio-test-' . uniqid();
+        $this->configDir = $this->root . '/config/';
+        $this->coreIconDir = $this->root . '/core/img/filetypes/';
+        mkdir($this->configDir, 0777, true);
+        mkdir($this->coreIconDir, 0777, true);
+
         \OC::$configDir = $this->configDir;
+        \OC::$SERVERROOT = $this->root;
 
         $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
     }
 
     protected function tearDown(): void {
-        foreach (['mimetypemapping.json', 'mimetypealiases.json'] as $file) {
-            @unlink($this->configDir . $file);
+        foreach (glob($this->configDir . '*') ?: [] as $file) {
+            unlink($file);
         }
-        @rmdir($this->configDir);
+        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
+            unlink($file);
+        }
+        foreach ([$this->configDir, $this->root . '/core/img/filetypes', $this->root . '/core/img', $this->root . '/core', $this->root] as $dir) {
+            @rmdir($dir);
+        }
+    }
+
+    private function runStep(): void {
+        $step = new UnregisterMimeType($this->mimeTypeLoader);
+        $this->assertSame('Unregister MIME type for Diagramming', $step->getName());
+        $step->run($this->createMock(IOutput::class));
     }
 
     public function testRunRemovesOnlyDrawioEntries(): void {
@@ -50,20 +68,32 @@ final class UnregisterMimeTypeTest extends TestCase {
                 return 1;
             });
 
-        $step = new UnregisterMimeType($this->mimeTypeLoader);
-        $this->assertSame('Unregister MIME type for Diagramming', $step->getName());
-        $step->run($this->createMock(IOutput::class));
+        $this->runStep();
 
         $this->assertSame(['drawio' => 3, 'dwb' => 3], $filecacheUpdates);
 
-        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
+        $mapping = json_decode((string)file_get_contents($this->configDir . 'mimetypemapping.json'), true);
         $this->assertArrayNotHasKey('drawio', $mapping);
         $this->assertArrayNotHasKey('dwb', $mapping);
         $this->assertSame(['application/x-mind'], $mapping['mind']);
 
-        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
+        $aliases = json_decode((string)file_get_contents($this->configDir . 'mimetypealiases.json'), true);
         $this->assertArrayNotHasKey('application/x-drawio', $aliases);
         $this->assertArrayNotHasKey('application/x-drawio-wb', $aliases);
         $this->assertSame('mind', $aliases['application/x-mind']);
+    }
+
+    public function testRunRemovesIconsFromTheNextcloudCore(): void {
+        file_put_contents($this->coreIconDir . 'drawio.svg', '<svg/>');
+        file_put_contents($this->coreIconDir . 'dwb.svg', '<svg/>');
+        file_put_contents($this->coreIconDir . 'text.svg', '<svg/>');
+        $this->mimeTypeLoader->method('getId')->willReturn(3);
+        $this->mimeTypeLoader->method('updateFilecache')->willReturn(1);
+
+        $this->runStep();
+
+        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
+        $this->assertFileDoesNotExist($this->coreIconDir . 'dwb.svg');
+        $this->assertFileExists($this->coreIconDir . 'text.svg');
     }
 }


### PR DESCRIPTION
## Summary

Upgraded instances that once ran an app version <= 4.2.5 fail `occ integrity:check-core` and cannot be cleanly verified. This adds a one-time cleanup to the register repair step and stops the app from re-creating the condition.

Versions up to 4.2.5 copied the file type icons into `core/img/filetypes/` and regenerated `core/js/mimetypelist.js`. 4.3.0 stopped doing that, but nothing ever removed what the older versions had written, so those instances still report:

```
- INVALID_HASH:    core/js/mimetypelist.js
- EXTRA_FILE:      core/img/filetypes/drawio.svg
                   core/img/filetypes/dwb.svg
```

`RegisterMimeType` also still writes `config/mimetypealiases.json`. Those aliases only ever pointed at the core icons, so since 4.3.0 they do nothing useful - but the next `occ maintenance:mimetype:update-js` (run by an admin or another app) bakes them back into `core/js/mimetypelist.js` and re-breaks the integrity check.