### PR TITLE
Fix settings e2e test posting to the old /ajax/settings route

### DIFF
--- a/tests/e2e/SettingsAndTemplatesE2eTest.php
+++ b/tests/e2e/SettingsAndTemplatesE2eTest.php
@@ -11,7 +11,7 @@ namespace OCA\Drawio\Tests\E2e;
 final class SettingsAndTemplatesE2eTest extends E2ETestCase {
 
     private static function postSettings(string $whiteboards): array {
-        $response = self::apiClient()->post('/index.php/apps/drawio/ajax/settings', [
+        $response = self::apiClient()->post('/index.php/apps/drawio/ajax/adminSettings', [
             'form_params' => [
                 'drawioUrl' => '',
                 'offlineMode' => 'no',


### PR DESCRIPTION
## Summary

`SettingsAndTemplatesE2eTest` still posts admin settings to `/index.php/apps/drawio/ajax/settings`, but that route was renamed to `/ajax/adminSettings` when personal settings were split out (`AdminSettingsController` / `PersonalSettingsController`).

This went unnoticed because the end-to-end job is currently disabled in CI. The admin settings JavaScript already posts to `/ajax/adminSettings`; only the test lagged behind.

Pointing this out in the original PR would be appreciated @arnowelzel before https://github.com/arnowelzel/drawio-nextcloud/commit/bd9395d606ecabbdfe7c4fc1ded1730cf6188946 😉 (could be re-enabled after merging this PR) 