### PR TITLE
Update app icon to fix visibiliy issues in the app list

### DIFF
--- a/img/app.svg
+++ b/img/app.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="24 26 68 68" fill="#000" stroke="#000">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="24 26 68 68" fill="#fff" stroke="#fff">
   <path
      d=""
      style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;stroke:none;stroke-miterlimit:10;enable-background:accumulate;stop-color:#000000;stop-opacity:1"


### PR DESCRIPTION
It seems, SVG elements need to be formatted to use the color `#fff` for the parts which should be always visible in different theming settings (light/dark).