### PR TITLE
Revert mimetype repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.3.3
+
+- Reverted mitigation to fix MIME type errors when upgrading from version 4.2.5 or older to avoid errors during Nextcloud upgrade
+
 ## 4.3.2
 
 - Additional mitigation to fix MIME type errors when upgrading from version 4.2.5 or older (thanks to solracfs)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 - Supports public share links (read-only and editable)
 - Offline mode for privacy-sensitive deployments
 - Configurable editor URL for self-hosted diagrams.net instances]]></description>
-    <version>4.3.2</version>
+    <version>4.3.3</version>
     <licence>agpl</licence>
     <author>Arno Welzel</author>
     <namespace>Drawio</namespace>

--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -1,21 +1,13 @@
 <?php
 namespace OCA\Drawio\Migration;
 
-use OCA\Drawio\AppInfo\Application;
 use OCP\Files\IMimeTypeLoader;
-use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 
 class RegisterMimeType extends MimeTypeMigration
 {
-    // Set once the leftovers of app versions up to 4.2.x have been removed, so
-    // that an administrator who deliberately restores the core icons and
-    // aliases afterwards keeps them.
-    const CLEANUP_FLAG = 'LegacyCoreCleanupDone';
-
     public function __construct(
-        IMimeTypeLoader $mimeTypeLoader,
-        private IAppConfig $appConfig
+        IMimeTypeLoader $mimeTypeLoader
     )
     {
         parent::__construct($mimeTypeLoader);
@@ -48,27 +40,6 @@ class RegisterMimeType extends MimeTypeMigration
         ]);
     }
 
-    /**
-     * Undo what app versions up to 4.2.x changed outside of this app, which
-     * makes "occ integrity:check-core" report EXTRA_FILE for the icons. Runs
-     * once per instance.
-     *
-     * core/js/mimetypelist.js cannot be repaired from here: its original
-     * content is only known to the Nextcloud release, so restoring it stays a
-     * manual step for the administrator.
-     */
-    private function cleanUpLegacyCoreChanges(IOutput $output): void
-    {
-        if ($this->appConfig->getValueString(Application::APP_ID, self::CLEANUP_FLAG) === 'yes') {
-            return;
-        }
-
-        $this->removeLegacyCoreIcons($output);
-        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEALIASES, self::LEGACY_ALIASES);
-
-        $this->appConfig->setValueString(Application::APP_ID, self::CLEANUP_FLAG, 'yes');
-    }
-
     public function run(IOutput $output): void
     {
         $output->info('Registering the mimetype...');
@@ -78,9 +49,6 @@ class RegisterMimeType extends MimeTypeMigration
 
         // Register the mime type for new files
         $this->registerForNewFiles();
-
-        // Clean up what older versions changed in the Nextcloud core
-        $this->cleanUpLegacyCoreChanges($output);
 
         $output->info('The mimetype was successfully registered.');
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "drawio",
     "description": "Integrates draw.io diagrams editor with Nextcloud",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "author": "Arno Welzel",
 
     "license": "agpl",


### PR DESCRIPTION
## Summary

During repair steps, it is not possible to access the app configuration and also `\OCA\Drawio\AppInfo\Application::APP_ID` seems not to be availble depending on which version you are upgrading from. It is better not to try to do the automatic fix. For users who want to repair their existing Nextcloud installation, there are instructions in the FAQ which is also mention in the Diagrams admin settings page.

## Related issues

Fixes #27

## Testing

- [x] Tested against the [test checklist](../blob/main/DEV.md#test-checklist) (relevant sections)
- [x] Ran `npm run build` successfully
