### PR TITLE
Revert mimetype fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.3.3
+
+- Reverting mitigation to fix MIME type errors when upgrading from version 4.2.5 or older
+
 ## 4.3.2
 
 - Additional mitigation to fix MIME type errors when upgrading from version 4.2.5 or older (thanks to solracfs)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 - Supports public share links (read-only and editable)
 - Offline mode for privacy-sensitive deployments
 - Configurable editor URL for self-hosted diagrams.net instances]]></description>
-    <version>4.3.2</version>
+    <version>4.3.3</version>
     <licence>agpl</licence>
     <author>Arno Welzel</author>
     <namespace>Drawio</namespace>

--- a/lib/Migration/MimeTypeMigration.php
+++ b/lib/Migration/MimeTypeMigration.php
@@ -2,16 +2,14 @@
 namespace OCA\Drawio\Migration;
 
 /**
- * NOTE: This class and its subclasses use \OC::$configDir and \OC::$SERVERROOT,
- * for which there is no public OCP API. Registering custom MIME types via
- * config/mimetypemapping.json is the approach recommended by the Nextcloud
- * documentation and shared by other apps (Keeweb, Mind Map). These usages
- * should be reviewed if Nextcloud provides a public MIME type registration API
- * (https://github.com/nextcloud/server/issues/10131).
+ * NOTE: This class and its subclasses use \OC::$configDir, for which there is
+ * no public OCP API. Registering custom MIME types via config/mimetypemapping.json
+ * is the approach recommended by the Nextcloud documentation and shared by other
+ * apps (Keeweb, Mind Map). These usages should be reviewed if Nextcloud provides
+ * a public MIME type registration API (https://github.com/nextcloud/server/issues/9192).
  **/
 
 use OCP\Files\IMimeTypeLoader;
-use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
 abstract class MimeTypeMigration implements IRepairStep
@@ -19,96 +17,7 @@ abstract class MimeTypeMigration implements IRepairStep
     const CUSTOM_MIMETYPEMAPPING = 'mimetypemapping.json';
     const CUSTOM_MIMETYPEALIASES = 'mimetypealiases.json';
 
-    // File type icons that app versions up to 4.2.x copied into the Nextcloud
-    // core, where the code integrity check reports them as EXTRA_FILE
-    // (https://github.com/jgraph/drawio-nextcloud/issues/70).
-    const LEGACY_CORE_ICONS = ['drawio.svg', 'dwb.svg'];
-
-    // MIME type aliases those versions registered so the icons above were used.
-    // The app no longer ships those icons, so the aliases have no effect - but
-    // they would be baked back into core/js/mimetypelist.js by the next
-    // "occ maintenance:mimetype:update-js" run and break the integrity check.
-    const LEGACY_ALIASES = [
-        'application/x-drawio' => 'drawio',
-        'application/x-drawio-wb' => 'dwb'
-    ];
-
     public function __construct(protected IMimeTypeLoader $mimeTypeLoader)
     {
-    }
-
-    /**
-     * Delete the file type icons older versions of this app copied into the
-     * Nextcloud core directory.
-     */
-    protected function removeLegacyCoreIcons(IOutput $output): void
-    {
-        foreach (self::LEGACY_CORE_ICONS as $icon) {
-            $path = \OC::$SERVERROOT . '/core/img/filetypes/' . $icon;
-
-            if (!file_exists($path)) {
-                continue;
-            }
-
-            if (@unlink($path)) {
-                $output->info('Removed ' . $path . ', which an older version of this app copied into the Nextcloud core');
-            } else {
-                $output->warning('Could not remove ' . $path . '. Delete it manually to fix the code integrity check.');
-            }
-        }
-    }
-
-    /**
-     * Merge the given entries into a MIME type configuration file, keeping the
-     * entries other apps have registered.
-     */
-    protected function appendToFile(string $filename, array $data): void
-    {
-        $config = $this->readFile($filename);
-
-        foreach ($data as $key => $value) {
-            $config[$key] = $value;
-        }
-
-        $this->writeFile($filename, $config);
-    }
-
-    /**
-     * Remove the given entries from a MIME type configuration file, keeping the
-     * entries other apps have registered.
-     */
-    protected function removeFromFile(string $filename, array $data): void
-    {
-        if (!file_exists($filename)) {
-            return;
-        }
-
-        $config = $this->readFile($filename);
-
-        foreach (array_keys($data) as $key) {
-            unset($config[$key]);
-        }
-
-        $this->writeFile($filename, $config);
-    }
-
-    private function readFile(string $filename): array
-    {
-        if (!file_exists($filename)) {
-            return [];
-        }
-
-        $config = json_decode((string)file_get_contents($filename), true);
-
-        return is_array($config) ? $config : [];
-    }
-
-    private function writeFile(string $filename, array $config): void
-    {
-        // An empty array would be encoded as "[]", but Nextcloud expects these
-        // files to hold a JSON object.
-        $data = $config === [] ? new \stdClass() : $config;
-
-        file_put_contents($filename, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }

--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -1,26 +1,10 @@
 <?php
 namespace OCA\Drawio\Migration;
 
-use OCA\Drawio\AppInfo\Application;
-use OCP\Files\IMimeTypeLoader;
-use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 
 class RegisterMimeType extends MimeTypeMigration
 {
-    // Set once the leftovers of app versions up to 4.2.x have been removed, so
-    // that an administrator who deliberately restores the core icons and
-    // aliases afterwards keeps them.
-    const CLEANUP_FLAG = 'LegacyCoreCleanupDone';
-
-    public function __construct(
-        IMimeTypeLoader $mimeTypeLoader,
-        private IAppConfig $appConfig
-    )
-    {
-        parent::__construct($mimeTypeLoader);
-    }
-
     public function getName(): string
     {
         return 'Register MIME types for Diagramming';
@@ -37,36 +21,18 @@ class RegisterMimeType extends MimeTypeMigration
 
     private function registerForNewFiles(): void
     {
-        // Only the extension to MIME type mapping is registered. The icon
-        // aliases are deliberately not written: the app does not ship icons into
-        // the Nextcloud core anymore, so they would have no effect other than
-        // breaking the code integrity check when core/js/mimetypelist.js is
-        // regenerated.
-        $this->appendToFile(\OC::$configDir . self::CUSTOM_MIMETYPEMAPPING, [
+        $configDir = \OC::$configDir;
+        $mimetypealiasesFile = $configDir . self::CUSTOM_MIMETYPEALIASES;
+        $mimetypemappingFile = $configDir . self::CUSTOM_MIMETYPEMAPPING;
+
+        $this->appendToFile($mimetypealiasesFile, [
+            'application/x-drawio' => 'drawio',
+            'application/x-drawio-wb' => 'dwb'
+        ]);
+        $this->appendToFile($mimetypemappingFile, [
             'drawio' => ['application/x-drawio'],
             'dwb' => ['application/x-drawio-wb']
         ]);
-    }
-
-    /**
-     * Undo what app versions up to 4.2.x changed outside of this app, which
-     * makes "occ integrity:check-core" report EXTRA_FILE for the icons. Runs
-     * once per instance.
-     *
-     * core/js/mimetypelist.js cannot be repaired from here: its original
-     * content is only known to the Nextcloud release, so restoring it stays a
-     * manual step for the administrator.
-     */
-    private function cleanUpLegacyCoreChanges(IOutput $output): void
-    {
-        if ($this->appConfig->getValueString(Application::APP_ID, self::CLEANUP_FLAG) === 'yes') {
-            return;
-        }
-
-        $this->removeLegacyCoreIcons($output);
-        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEALIASES, self::LEGACY_ALIASES);
-
-        $this->appConfig->setValueString(Application::APP_ID, self::CLEANUP_FLAG, 'yes');
     }
 
     public function run(IOutput $output): void
@@ -79,9 +45,19 @@ class RegisterMimeType extends MimeTypeMigration
         // Register the mime type for new files
         $this->registerForNewFiles();
 
-        // Clean up what older versions changed in the Nextcloud core
-        $this->cleanUpLegacyCoreChanges($output);
-
         $output->info('The mimetype was successfully registered.');
+    }
+
+    private function appendToFile(string $filename, array $data): void
+    {
+        $obj = [];
+        if (file_exists($filename)) {
+            $content = file_get_contents($filename);
+            $obj = json_decode($content, true);
+        }
+        foreach ($data as $key => $value) {
+            $obj[$key] = $value;
+        }
+        file_put_contents($filename, json_encode($obj,  JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
     }
 }

--- a/lib/Migration/UnregisterMimeType.php
+++ b/lib/Migration/UnregisterMimeType.php
@@ -5,42 +5,55 @@ use OCP\Migration\IOutput;
 
 class UnregisterMimeType extends MimeTypeMigration
 {
-    public function getName(): string
+    public function getName()
     {
         return 'Unregister MIME type for Diagramming';
     }
 
-    private function unregisterForExistingFiles(): void
+    private function unregisterForExistingFiles()
     {
         $mimeTypeId = $this->mimeTypeLoader->getId('application/octet-stream');
         $this->mimeTypeLoader->updateFilecache('drawio', $mimeTypeId);
         $this->mimeTypeLoader->updateFilecache('dwb', $mimeTypeId);
     }
 
-    private function unregisterForNewFiles(): void
+    private function unregisterForNewFiles()
     {
-        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEMAPPING, [
-            'drawio' => ['application/x-drawio'],
-            'dwb' => ['application/x-drawio-wb']
-        ]);
+        $configDir = \OC::$configDir;
+        $mimetypealiasesFile = $configDir . self::CUSTOM_MIMETYPEALIASES;
+        $mimetypemappingFile = $configDir . self::CUSTOM_MIMETYPEMAPPING;
 
-        // Written by app versions up to 4.2.x
-        $this->removeFromFile(\OC::$configDir . self::CUSTOM_MIMETYPEALIASES, self::LEGACY_ALIASES);
+        $this->removeFromFile($mimetypealiasesFile, [
+            'application/x-drawio' => 'drawio',
+            'application/x-drawio-wb' => 'dwb'
+        ]);
+        $this->removeFromFile($mimetypemappingFile, [
+            'drawio' => ['application/x-drawio'],
+            'dwb' => ['application/x-drawio-wb']]);
     }
 
-    public function run(IOutput $output): void
+    public function run(IOutput $output)
     {
         $output->info('Unregistering the mimetype...');
 
-        // Reset existing files to the generic MIME type
+        // Register the mime type for existing files
         $this->unregisterForExistingFiles();
 
-        // Remove the MIME type registration for new files
+        // Register the mime type for new files
         $this->unregisterForNewFiles();
 
-        // Remove the icons older versions copied into the Nextcloud core
-        $this->removeLegacyCoreIcons($output);
-
         $output->info('The mimetype was successfully unregistered.');
+    }
+
+    private function removeFromFile(string $filename, array $data) {
+        $obj = [];
+        if (file_exists($filename)) {
+            $content = file_get_contents($filename);
+            $obj = json_decode($content, true);
+        }
+        foreach ($data as $key => $value) {
+            unset($obj[$key]);
+        }
+        file_put_contents($filename, json_encode($obj,  JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES));
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "drawio",
     "description": "Integrates draw.io diagrams editor with Nextcloud",
-    "version": "4.3.2",
+    "version": "4.3.3",
     "author": "Arno Welzel",
 
     "license": "agpl",

--- a/tests/unit/Migration/RegisterMimeTypeTest.php
+++ b/tests/unit/Migration/RegisterMimeTypeTest.php
@@ -1,7 +1,4 @@
 <?php
-
-declare(strict_types=1);
-
 namespace OCA\Drawio\Tests\Unit\Migration;
 
 use OCA\Drawio\Migration\RegisterMimeType;

--- a/tests/unit/Migration/RegisterMimeTypeTest.php
+++ b/tests/unit/Migration/RegisterMimeTypeTest.php
@@ -6,92 +6,42 @@ namespace OCA\Drawio\Tests\Unit\Migration;
 
 use OCA\Drawio\Migration\RegisterMimeType;
 use OCP\Files\IMimeTypeLoader;
-use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class RegisterMimeTypeTest extends TestCase {
 
-    private string $root;
     private string $configDir;
-    private string $coreIconDir;
     private IMimeTypeLoader&MockObject $mimeTypeLoader;
 
-    /** @var array<string, string> */
-    private array $appValues = [];
-
     protected function setUp(): void {
-        $this->root = sys_get_temp_dir() . '/drawio-test-' . uniqid();
-        $this->configDir = $this->root . '/config/';
-        $this->coreIconDir = $this->root . '/core/img/filetypes/';
-        mkdir($this->configDir, 0777, true);
-        mkdir($this->coreIconDir, 0777, true);
-
+        $this->configDir = sys_get_temp_dir() . '/drawio-test-' . uniqid() . '/';
+        mkdir($this->configDir);
         \OC::$configDir = $this->configDir;
-        \OC::$SERVERROOT = $this->root;
 
         $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
-        $this->mimeTypeLoader->method('getId')->willReturnMap([
-            ['application/x-drawio', 7],
-            ['application/x-drawio-wb', 8],
-        ]);
-        $this->mimeTypeLoader->method('updateFilecache')->willReturn(1);
-
-        $this->appValues = [];
     }
 
     protected function tearDown(): void {
-        foreach (glob($this->configDir . '*') ?: [] as $file) {
-            unlink($file);
+        foreach (['mimetypemapping.json', 'mimetypealiases.json'] as $file) {
+            @unlink($this->configDir . $file);
         }
-        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
-            unlink($file);
-        }
-        foreach ([$this->configDir, $this->root . '/core/img/filetypes', $this->root . '/core/img', $this->root . '/core', $this->root] as $dir) {
-            @rmdir($dir);
-        }
-    }
-
-    private function createAppConfig(): IAppConfig&MockObject {
-        $appConfig = $this->createMock(IAppConfig::class);
-        $appConfig->method('getValueString')->willReturnCallback(
-            fn (string $app, string $key, string $default = '') => $this->appValues[$key] ?? $default
-        );
-        $appConfig->method('setValueString')->willReturnCallback(
-            function (string $app, string $key, string $value): bool {
-                $this->appValues[$key] = $value;
-                return true;
-            }
-        );
-        return $appConfig;
+        @rmdir($this->configDir);
     }
 
     private function runStep(): void {
-        $step = new RegisterMimeType($this->mimeTypeLoader, $this->createAppConfig());
+        $step = new RegisterMimeType($this->mimeTypeLoader);
         $this->assertSame('Register MIME types for Diagramming', $step->getName());
         $step->run($this->createMock(IOutput::class));
     }
 
-    private function writeLegacyIcons(): void {
-        file_put_contents($this->coreIconDir . 'drawio.svg', '<svg>old drawio</svg>');
-        file_put_contents($this->coreIconDir . 'dwb.svg', '<svg>old dwb</svg>');
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function readConfig(string $name): array {
-        return json_decode((string)file_get_contents($this->configDir . $name), true);
-    }
-
-    public function testRunWritesMimeTypeMapping(): void {
-        $filecacheUpdates = [];
-        $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
+    public function testRunWritesMimeTypeConfigFiles(): void {
         $this->mimeTypeLoader->method('getId')->willReturnMap([
             ['application/x-drawio', 7],
             ['application/x-drawio-wb', 8],
         ]);
+        $filecacheUpdates = [];
         $this->mimeTypeLoader->expects($this->exactly(2))->method('updateFilecache')
             ->willReturnCallback(function (string $ext, int $mimeTypeId) use (&$filecacheUpdates): int {
                 $filecacheUpdates[$ext] = $mimeTypeId;
@@ -102,104 +52,27 @@ final class RegisterMimeTypeTest extends TestCase {
 
         $this->assertSame(['drawio' => 7, 'dwb' => 8], $filecacheUpdates);
 
-        $mapping = $this->readConfig('mimetypemapping.json');
+        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
         $this->assertSame(['application/x-drawio'], $mapping['drawio']);
         $this->assertSame(['application/x-drawio-wb'], $mapping['dwb']);
-    }
 
-    /**
-     * Regression test: writing the icon aliases makes the next
-     * "occ maintenance:mimetype:update-js" bake them into
-     * core/js/mimetypelist.js, which breaks the code integrity check. The app
-     * does not ship the icons they refer to since 4.3.0.
-     */
-    public function testRunDoesNotWriteIconAliases(): void {
-        $this->runStep();
-
-        $this->assertFileDoesNotExist($this->configDir . 'mimetypealiases.json');
-    }
-
-    public function testRunRemovesAliasesWrittenByOlderVersions(): void {
-        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode([
-            'application/x-drawio' => 'drawio',
-            'application/x-drawio-wb' => 'dwb',
-            'application/x-mind' => 'mind',
-        ]));
-
-        $this->runStep();
-
-        $aliases = $this->readConfig('mimetypealiases.json');
-        $this->assertArrayNotHasKey('application/x-drawio', $aliases);
-        $this->assertArrayNotHasKey('application/x-drawio-wb', $aliases);
-        $this->assertSame('mind', $aliases['application/x-mind'], "Other apps' aliases must be kept");
-    }
-
-    public function testEmptiedAliasFileStaysAJsonObject(): void {
-        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode([
-            'application/x-drawio' => 'drawio',
-            'application/x-drawio-wb' => 'dwb',
-        ]));
-
-        $this->runStep();
-
-        $contents = trim((string)file_get_contents($this->configDir . 'mimetypealiases.json'));
-        $this->assertSame('{}', $contents, 'Nextcloud expects a JSON object, not an empty array');
-    }
-
-    /**
-     * Regression test for https://github.com/jgraph/drawio-nextcloud/issues/70:
-     * versions up to 4.2.x copied the file type icons into the Nextcloud core,
-     * where they are reported as EXTRA_FILE by "occ integrity:check-core".
-     */
-    public function testRunRemovesIconsCopiedIntoTheCoreByOlderVersions(): void {
-        $this->writeLegacyIcons();
-
-        $this->runStep();
-
-        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
-        $this->assertFileDoesNotExist($this->coreIconDir . 'dwb.svg');
-    }
-
-    public function testRunKeepsUnrelatedCoreIcons(): void {
-        file_put_contents($this->coreIconDir . 'text.svg', '<svg>text</svg>');
-
-        $this->runStep();
-
-        $this->assertFileExists($this->coreIconDir . 'text.svg');
-    }
-
-    public function testCleanupRunsOnlyOnce(): void {
-        $this->writeLegacyIcons();
-        $this->runStep();
-        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
-
-        // An administrator restoring the icons afterwards keeps them
-        $this->writeLegacyIcons();
-        $this->runStep();
-
-        $this->assertFileExists($this->coreIconDir . 'drawio.svg');
-        $this->assertFileExists($this->coreIconDir . 'dwb.svg');
+        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
+        $this->assertSame('drawio', $aliases['application/x-drawio']);
+        $this->assertSame('dwb', $aliases['application/x-drawio-wb']);
     }
 
     public function testRunPreservesForeignEntriesInExistingConfigFiles(): void {
         file_put_contents($this->configDir . 'mimetypemapping.json', json_encode(['mind' => ['application/x-mind']]));
+        file_put_contents($this->configDir . 'mimetypealiases.json', json_encode(['application/x-mind' => 'mind']));
 
         $this->runStep();
 
-        $mapping = $this->readConfig('mimetypemapping.json');
+        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
         $this->assertSame(['application/x-mind'], $mapping['mind']);
         $this->assertSame(['application/x-drawio'], $mapping['drawio']);
-    }
 
-    public function testRunSucceedsWhenCoreIconsAreNotWritable(): void {
-        // No icons and no core directory at all must not fail the upgrade
-        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
-            unlink($file);
-        }
-        rmdir($this->coreIconDir);
-
-        $this->runStep();
-
-        $this->assertFileExists($this->configDir . 'mimetypemapping.json');
+        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
+        $this->assertSame('mind', $aliases['application/x-mind']);
+        $this->assertSame('drawio', $aliases['application/x-drawio']);
     }
 }

--- a/tests/unit/Migration/UnregisterMimeTypeTest.php
+++ b/tests/unit/Migration/UnregisterMimeTypeTest.php
@@ -1,7 +1,4 @@
 <?php
-
-declare(strict_types=1);
-
 namespace OCA\Drawio\Tests\Unit\Migration;
 
 use OCA\Drawio\Migration\UnregisterMimeType;

--- a/tests/unit/Migration/UnregisterMimeTypeTest.php
+++ b/tests/unit/Migration/UnregisterMimeTypeTest.php
@@ -12,40 +12,22 @@ use PHPUnit\Framework\TestCase;
 
 final class UnregisterMimeTypeTest extends TestCase {
 
-    private string $root;
     private string $configDir;
-    private string $coreIconDir;
     private IMimeTypeLoader&MockObject $mimeTypeLoader;
 
     protected function setUp(): void {
-        $this->root = sys_get_temp_dir() . '/drawio-test-' . uniqid();
-        $this->configDir = $this->root . '/config/';
-        $this->coreIconDir = $this->root . '/core/img/filetypes/';
-        mkdir($this->configDir, 0777, true);
-        mkdir($this->coreIconDir, 0777, true);
-
+        $this->configDir = sys_get_temp_dir() . '/drawio-test-' . uniqid() . '/';
+        mkdir($this->configDir);
         \OC::$configDir = $this->configDir;
-        \OC::$SERVERROOT = $this->root;
 
         $this->mimeTypeLoader = $this->createMock(IMimeTypeLoader::class);
     }
 
     protected function tearDown(): void {
-        foreach (glob($this->configDir . '*') ?: [] as $file) {
-            unlink($file);
+        foreach (['mimetypemapping.json', 'mimetypealiases.json'] as $file) {
+            @unlink($this->configDir . $file);
         }
-        foreach (glob($this->coreIconDir . '*') ?: [] as $file) {
-            unlink($file);
-        }
-        foreach ([$this->configDir, $this->root . '/core/img/filetypes', $this->root . '/core/img', $this->root . '/core', $this->root] as $dir) {
-            @rmdir($dir);
-        }
-    }
-
-    private function runStep(): void {
-        $step = new UnregisterMimeType($this->mimeTypeLoader);
-        $this->assertSame('Unregister MIME type for Diagramming', $step->getName());
-        $step->run($this->createMock(IOutput::class));
+        @rmdir($this->configDir);
     }
 
     public function testRunRemovesOnlyDrawioEntries(): void {
@@ -68,32 +50,20 @@ final class UnregisterMimeTypeTest extends TestCase {
                 return 1;
             });
 
-        $this->runStep();
+        $step = new UnregisterMimeType($this->mimeTypeLoader);
+        $this->assertSame('Unregister MIME type for Diagramming', $step->getName());
+        $step->run($this->createMock(IOutput::class));
 
         $this->assertSame(['drawio' => 3, 'dwb' => 3], $filecacheUpdates);
 
-        $mapping = json_decode((string)file_get_contents($this->configDir . 'mimetypemapping.json'), true);
+        $mapping = json_decode(file_get_contents($this->configDir . 'mimetypemapping.json'), true);
         $this->assertArrayNotHasKey('drawio', $mapping);
         $this->assertArrayNotHasKey('dwb', $mapping);
         $this->assertSame(['application/x-mind'], $mapping['mind']);
 
-        $aliases = json_decode((string)file_get_contents($this->configDir . 'mimetypealiases.json'), true);
+        $aliases = json_decode(file_get_contents($this->configDir . 'mimetypealiases.json'), true);
         $this->assertArrayNotHasKey('application/x-drawio', $aliases);
         $this->assertArrayNotHasKey('application/x-drawio-wb', $aliases);
         $this->assertSame('mind', $aliases['application/x-mind']);
-    }
-
-    public function testRunRemovesIconsFromTheNextcloudCore(): void {
-        file_put_contents($this->coreIconDir . 'drawio.svg', '<svg/>');
-        file_put_contents($this->coreIconDir . 'dwb.svg', '<svg/>');
-        file_put_contents($this->coreIconDir . 'text.svg', '<svg/>');
-        $this->mimeTypeLoader->method('getId')->willReturn(3);
-        $this->mimeTypeLoader->method('updateFilecache')->willReturn(1);
-
-        $this->runStep();
-
-        $this->assertFileDoesNotExist($this->coreIconDir . 'drawio.svg');
-        $this->assertFileDoesNotExist($this->coreIconDir . 'dwb.svg');
-        $this->assertFileExists($this->coreIconDir . 'text.svg');
     }
 }


### PR DESCRIPTION
## Summary

Unfortunately, the automatic repair during an upgrade does not work in real installations. At runtime, `\OCA\Drawio\AppInfo\Application::APP_ID` is unknown.

## Related issues

Fixes #27 
