### PR TITLE
Honor dirId when creating files through a folder share

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -402,11 +402,14 @@ class EditorController extends Controller
     #[PublicPage]
     public function create(string $name, string $dirId, $shareToken): array
     {
-        list ($folder, $writeable) = $this->getDir($dirId, $shareToken);
-
-        if ($folder === NULL) {
+        try {
+            list ($folder, $writeable) = $this->getDir($dirId, $shareToken);
+        } catch (NotFoundException $e) {
             $this->logger->info("Folder for file creation was not found: " . $dirId, ["app" => $this->appName]);
             return ["error" => $this->trans->t("The required folder was not found")];
+        } catch (ForbiddenException $e) {
+            $this->logger->info("Folder for file creation without permission: " . $dirId, ["app" => $this->appName]);
+            return ["error" => $this->trans->t("You don't have enough permission to create file")];
         }
 
         if (!$writeable) {
@@ -662,6 +665,16 @@ class EditorController extends Controller
         if (!empty($shareToken))
         {
             list ($dir, $share) = $this->getNodeByToken($shareToken);
+
+            if (!empty($dirId) && $dir instanceof Folder && (int)$dirId !== $dir->getId()) // Subfolder of a shared folder case
+            {
+                $dir = $dir->getFirstNodeById((int)$dirId);
+
+                if ($dir === null)
+                {
+                    throw new NotFoundException();
+                }
+            }
         }
         else if (!empty($dirId) && $this->userSession->isLoggedIn())
         {
@@ -679,7 +692,7 @@ class EditorController extends Controller
             throw new BadRequestException(['fileId', 'shareToken']);
         }
 
-        if ($dir === null)
+        if (!($dir instanceof Folder))
         {
             throw new NotFoundException();
         }

--- a/tests/e2e/E2ETestCase.php
+++ b/tests/e2e/E2ETestCase.php
@@ -138,6 +138,13 @@ abstract class E2ETestCase extends TestCase {
         return $response->getStatusCode();
     }
 
+    protected static function davMkcol(string $path): int {
+        self::$cleanupPaths[] = $path;
+        $response = self::apiClient()->request('MKCOL',
+            '/remote.php/dav/files/' . self::$adminUser . '/' . ltrim($path, '/'));
+        return $response->getStatusCode();
+    }
+
     /**
      * @return array{fileid: int, contenttype: string}
      */

--- a/tests/e2e/PublicShareE2eTest.php
+++ b/tests/e2e/PublicShareE2eTest.php
@@ -30,6 +30,12 @@ final class PublicShareE2eTest extends E2ETestCase {
     private static int $openFileId;
     private static string $openShareToken;
 
+    private static string $folderName;
+    private static int $subfolderId;
+    private static string $folderShareToken;
+    private static string $outsideFolderName;
+    private static int $outsideFolderId;
+
     public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
 
@@ -45,16 +51,31 @@ final class PublicShareE2eTest extends E2ETestCase {
         self::$openFileId = self::davStat(self::$openFileName)['fileid'];
 
         self::$openShareToken = (string)self::createLinkShare(self::$openFileName)['token'];
+
+        self::$folderName = 'E2E-sharedir-' . uniqid();
+        self::davMkcol(self::$folderName);
+        self::davMkcol(self::$folderName . '/sub');
+        self::$subfolderId = self::davStat(self::$folderName . '/sub')['fileid'];
+
+        self::$outsideFolderName = 'E2E-outside-' . uniqid();
+        self::davMkcol(self::$outsideFolderName);
+        self::$outsideFolderId = self::davStat(self::$outsideFolderName)['fileid'];
+
+        self::$folderShareToken = (string)self::createLinkShare(self::$folderName, null, 5)['token']; // read + create
     }
 
     /**
      * @return array<string, mixed>
      */
-    private static function createLinkShare(string $path, ?string $password = null): array {
+    private static function createLinkShare(string $path, ?string $password = null, ?int $permissions = null): array {
         $share = ['path' => '/' . $path, 'shareType' => 3];
 
         if ($password !== null) {
             $share['password'] = $password;
+        }
+
+        if ($permissions !== null) {
+            $share['permissions'] = $permissions;
         }
 
         $response = self::apiClient()->post('/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json', [
@@ -293,5 +314,60 @@ final class PublicShareE2eTest extends E2ETestCase {
         $this->assertSame(200, $response->getStatusCode());
         $this->assertStringNotContainsString('core-public-share-auth', (string)$response->getBody(),
             'A link without a password must not show the password prompt');
+    }
+
+    // ---- file creation in an editable folder share ----
+
+    /**
+     * @return array{jar: CookieJar, token: string}
+     */
+    private function openFolderSharePage(): array {
+        $jar = new CookieJar();
+        $response = self::browserClient($jar)->get('/index.php/s/' . self::$folderShareToken);
+        $this->assertSame(200, $response->getStatusCode());
+
+        return ['jar' => $jar, 'token' => self::extractRequestToken((string)$response->getBody())];
+    }
+
+    private function createAnonymously(array $session, string $name, string $dirId): \Psr\Http\Message\ResponseInterface {
+        return self::browserClient($session['jar'])->post('/index.php/apps/drawio/ajax/new', [
+            'json' => ['name' => $name, 'dirId' => $dirId, 'shareToken' => self::$folderShareToken],
+            'headers' => ['requesttoken' => $session['token'], 'Accept' => 'application/json'],
+        ]);
+    }
+
+    /**
+     * Regression test: create() used to ignore dirId on the share-token path,
+     * silently creating the file in the share root and reporting the root as
+     * parentId.
+     */
+    public function testAnonymousCreateInSubfolderOfSharedFolderHonorsDirId(): void {
+        $session = $this->openFolderSharePage();
+        $name = 'E2E-created-' . uniqid() . '.drawio';
+
+        $response = $this->createAnonymously($session, $name, (string)self::$subfolderId);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = self::decodeJson((string)$response->getBody());
+        $this->assertArrayNotHasKey('error', $data, 'create failed: ' . json_encode($data));
+        $this->assertSame(self::$subfolderId, $data['parentId']);
+        $this->assertSame($data['id'], self::davStat(self::$folderName . '/sub/' . $name)['fileid'],
+            'The file must physically live in the requested subfolder');
+    }
+
+    public function testAnonymousCreateWithDirIdOutsideShareIsRejected(): void {
+        $session = $this->openFolderSharePage();
+        $name = 'E2E-escape-' . uniqid() . '.drawio';
+
+        $response = $this->createAnonymously($session, $name, (string)self::$outsideFolderId);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('The required folder was not found',
+            self::decodeJson((string)$response->getBody())['error'] ?? null);
+
+        $probe = self::apiClient()->request('PROPFIND',
+            '/remote.php/dav/files/' . self::$adminUser . '/' . self::$outsideFolderName . '/' . $name,
+            ['headers' => ['Depth' => '0']]);
+        $this->assertSame(404, $probe->getStatusCode(), 'No file may be created outside the share');
     }
 }

--- a/tests/unit/Controller/EditorControllerTest.php
+++ b/tests/unit/Controller/EditorControllerTest.php
@@ -573,6 +573,116 @@ final class EditorControllerTest extends TestCase {
         $this->assertSame("Can't create file", $result['error']);
     }
 
+    public function testCreateInSubfolderOfSharedFolderHonorsDirId(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $subfolder = $this->createMock(Folder::class);
+        $file = $this->createFile(['id' => 98, 'name' => 'New.drawio']);
+        $file->method('getParent')->willReturn($subfolder);
+        $subfolder->method('getId')->willReturn(5);
+        $subfolder->method('getNonExistingName')->with('New.drawio')->willReturn('New.drawio');
+        $subfolder->expects($this->once())->method('newFile')->with('New.drawio', ' ')->willReturn($file);
+
+        $sharedFolder = $this->createMock(Folder::class);
+        $sharedFolder->method('getId')->willReturn(10);
+        $sharedFolder->method('getFirstNodeById')->with(5)->willReturn($subfolder);
+        $sharedFolder->expects($this->never())->method('newFile');
+
+        $share = $this->createShare($sharedFolder, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+        $this->shareManager->method('getShareByToken')->with('tok123')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->with($share)->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '5', 'tok123');
+
+        $this->assertSame(98, $result['id']);
+        $this->assertSame(5, $result['parentId']);
+    }
+
+    public function testCreateInShareRootWhenNoDirId(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $sharedFolder = $this->createMock(Folder::class);
+        $file = $this->createFile(['id' => 98, 'name' => 'New.drawio']);
+        $file->method('getParent')->willReturn($sharedFolder);
+        $sharedFolder->method('getId')->willReturn(10);
+        $sharedFolder->method('getNonExistingName')->with('New.drawio')->willReturn('New.drawio');
+        $sharedFolder->expects($this->once())->method('newFile')->with('New.drawio', ' ')->willReturn($file);
+
+        $share = $this->createShare($sharedFolder, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+        $this->shareManager->method('getShareByToken')->with('tok123')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->with($share)->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '', 'tok123');
+
+        $this->assertSame(10, $result['parentId']);
+    }
+
+    public function testCreateWithShareRootDirIdCreatesInRoot(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $sharedFolder = $this->createMock(Folder::class);
+        $file = $this->createFile(['id' => 98, 'name' => 'New.drawio']);
+        $file->method('getParent')->willReturn($sharedFolder);
+        $sharedFolder->method('getId')->willReturn(10);
+        $sharedFolder->expects($this->never())->method('getFirstNodeById');
+        $sharedFolder->method('getNonExistingName')->with('New.drawio')->willReturn('New.drawio');
+        $sharedFolder->expects($this->once())->method('newFile')->with('New.drawio', ' ')->willReturn($file);
+
+        $share = $this->createShare($sharedFolder, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+        $this->shareManager->method('getShareByToken')->with('tok123')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->with($share)->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '10', 'tok123');
+
+        $this->assertSame(10, $result['parentId']);
+    }
+
+    public function testCreateWithDirIdOutsideShareReturnsError(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $sharedFolder = $this->createMock(Folder::class);
+        $sharedFolder->method('getId')->willReturn(10);
+        $sharedFolder->method('getFirstNodeById')->willReturn(null);
+        $sharedFolder->expects($this->never())->method('newFile');
+
+        $share = $this->createShare($sharedFolder, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+        $this->shareManager->method('getShareByToken')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '999', 'tok123');
+
+        $this->assertSame('The required folder was not found', $result['error']);
+    }
+
+    public function testCreateOnFileShareTokenReturnsError(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $sharedFile = $this->createFile();
+        $share = $this->createShare($sharedFile, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE);
+        $this->shareManager->method('getShareByToken')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '', 'tok123');
+
+        $this->assertSame('The required folder was not found', $result['error']);
+    }
+
+    public function testCreateWithoutCreatePermissionOnShareReturnsError(): void {
+        $this->userSession->method('isLoggedIn')->willReturn(false);
+
+        $sharedFolder = $this->createMock(Folder::class);
+        $sharedFolder->method('getId')->willReturn(10);
+        $sharedFolder->expects($this->never())->method('newFile');
+
+        $share = $this->createShare($sharedFolder, Constants::PERMISSION_READ);
+        $this->shareManager->method('getShareByToken')->willReturn($share);
+        $this->shareAuth->method('isAuthenticated')->willReturn(true);
+
+        $result = $this->createController()->create('New.drawio', '', 'tok123');
+
+        $this->assertSame("You don't have enough permission to create file", $result['error']);
+    }
+
     // ---- index ----
 
     public function testIndexRedirectsAnonymousUsersToLogin(): void {


### PR DESCRIPTION
## What happens today

`getDir()` only reads `dirId` on the logged-in branch. As soon as a share token is present, `getNodeByToken()` returns the share **root** and `dirId` is never looked at again. `POST /ajax/new` therefore always creates the file in the share root — and reports the share root as `parentId`, so the client is told the wrong location too.

Before the security fix in 4.3.6 the logged-in-with-token case crashed with a 500; since 4.3.6 it returns HTTP 200 with the file silently placed in the wrong folder. (The 4.3.6 reordering of `getDir()` was done for parity with `getFile()`, but `getFile()`'s descend-into-the-share step was not ported along with it.)

Two smaller pre-existing issues sit next to it:

* Passing a **file**-share token to `/ajax/new` reached `getNonExistingName()` on a `File` and died with a fatal error (500).
* `create()` never caught anything `getDir()` throws, so its `"The required folder was not found"` error branch was dead code — every failure surfaced as a 500 instead of the endpoint's documented JSON error shape.

## The fix

* `getDir()` now resolves `dirId` **inside** the share with `Folder::getFirstNodeById()`, exactly the way `getFile()` resolves a file inside a shared folder (so an id outside the share subtree yields not-found, and a `dirId` equal to the share root id keeps working).
* A final guard requires the resolved node to be a `Folder`, which also fixes the file-share-token fatal.
* `create()` maps `NotFoundException`/`ForbiddenException` from `getDir()` to its JSON error responses, making the previously dead error branch meaningful.

## Tests

* 6 new unit tests covering the share-token create path: subfolder honored, share root with empty/root `dirId`, `dirId` outside the share, file-share token, and a token without create permission.
* 2 new end-to-end tests: an anonymous visitor on an editable public folder share creates a file in a subfolder via `dirId` (asserting both the reported `parentId` and the file's physical location over WebDAV), and a `dirId` pointing outside the share is rejected without creating anything. Supporting this, `E2ETestCase` gains a `davMkcol()` helper and `createLinkShare()` accepts share permissions.

Full suite results: unit 112/112 green (19 pre-existing skips untouched here), e2e 25/25 green against Nextcloud 33.0.8.

Note: #59 re-enables the 19 skipped unit tests; the two branches touch neighbouring test code, so whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
