### PR TITLE
Re-enable the unit tests skipped in the security fix

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -560,13 +560,9 @@ class EditorController extends Controller
             throw new NotFoundException();
         }
 
-        $userFolder = $this->root->getUserFolder($user->getUID());
-
-        if ($userFolder === null) {
-            throw new NotFoundException();
-        }
-
-        $files = $userFolder->getById($fileId);
+        // getUserFolder(), never the root folder: IRootFolder::getById() spans every
+        // user's storage and hands back a node carrying the OWNER's permissions.
+        $files = $this->root->getUserFolder($user->getUID())->getById($fileId);
 
         if (empty($files)) {
             throw new NotFoundException();

--- a/tests/unit/Controller/EditorControllerTest.php
+++ b/tests/unit/Controller/EditorControllerTest.php
@@ -134,8 +134,8 @@ final class EditorControllerTest extends TestCase {
     }
 
     private function givenUserFile(File $file, string $relativePath = '/Test.drawio'): void {
-        $this->root->method('getById')->willReturn([$file]);
         $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$file]);
         $userFolder->method('getRelativePath')->willReturn($relativePath);
         $this->root->method('getUserFolder')->willReturn($userFolder);
     }
@@ -150,11 +150,12 @@ final class EditorControllerTest extends TestCase {
     // ---- load ----
 
     public function testLoadReturnsFilePayloadForLoggedInUser(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);
+        // Id resolution must stay scoped to the caller's user folder;
+        // IRootFolder::getById() spans every user's storage (GHSA-c9x8-9w2j-4m94).
+        $this->root->expects($this->never())->method('getById');
 
         $this->lockingProvider->expects($this->once())
             ->method('acquireLock')->with('drawio_97', ILockingProvider::LOCK_SHARED);
@@ -180,13 +181,11 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testLoadRejectsFolders(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $folder = $this->createMock(Folder::class);
         $folder->method('isReadable')->willReturn(true);
-        $this->root->method('getById')->willReturn([$folder]);
         $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$folder]);
         $this->root->method('getUserFolder')->willReturn($userFolder);
 
         $response = $this->createController()->load('97', null);
@@ -196,8 +195,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testLoadRejectsTooBigFiles(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['size' => 104857601]);
         $this->givenUserFile($file);
@@ -221,7 +218,9 @@ final class EditorControllerTest extends TestCase {
 
     public function testLoadUnknownFileIdIsNotFound(): void {
         $this->loginAs();
-        $this->root->method('getById')->willReturn([]);
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([]);
+        $this->root->method('getUserFolder')->willReturn($userFolder);
 
         $response = $this->createController()->load('404', null);
 
@@ -229,11 +228,11 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testLoadUnreadableFileIsForbidden(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['readable' => false]);
-        $this->root->method('getById')->willReturn([$file]);
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$file]);
+        $this->root->method('getUserFolder')->willReturn($userFolder);
 
         $response = $this->createController()->load('97', null);
 
@@ -241,8 +240,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testLoadReturns409WhenLockCannotBeAcquired(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);
@@ -342,8 +339,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testGetFileInfoFallsBackToUploadTimeWhenNoCreationTime(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['created' => 0, 'uploaded' => 1650000000]);
         $this->givenUserFile($file);
@@ -356,8 +351,6 @@ final class EditorControllerTest extends TestCase {
     // ---- save ----
 
     public function testSavePersistsContentAndReturnsNewEtag(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['etagSequence' => true]);
         $file->method('getEtag')->willReturnOnConsecutiveCalls('etag1', 'etag2');
@@ -379,8 +372,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSaveDetectsEtagConflict(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['etag' => 'current-etag']);
         $file->expects($this->never())->method('putContent');
@@ -395,8 +386,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSaveTreatsPostSaveHookFailureAsSuccessWhenEtagChanged(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['etagSequence' => true]);
         $file->method('getEtag')->willReturnOnConsecutiveCalls('etag1', 'etag2');
@@ -413,8 +402,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSaveFailsWhenHookFailsAndEtagUnchanged(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['etag' => 'etag1']);
         $file->method('putContent')->willThrowException(new \RuntimeException('write failed'));
@@ -426,8 +413,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSaveWithoutWritePermissionIsForbidden(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['updateable' => false]);
         $this->givenUserFile($file);
@@ -456,8 +441,6 @@ final class EditorControllerTest extends TestCase {
     // ---- savePreview ----
 
     public function testSavePreviewStoresDecodedImage(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);
@@ -474,8 +457,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSavePreviewCreatesPreviewFolderOnDemand(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);
@@ -491,8 +472,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testSavePreviewForbiddenWithoutWritePermission(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile(['updateable' => false]);
         $this->givenUserFile($file);
@@ -514,8 +493,6 @@ final class EditorControllerTest extends TestCase {
     // ---- create ----
 
     public function testCreateReturnsFileInfoArray(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $parent = $this->createMock(Folder::class);
         $parent->method('getId')->willReturn(5);
@@ -527,7 +504,10 @@ final class EditorControllerTest extends TestCase {
         $dir->method('isCreatable')->willReturn(true);
         $dir->method('getNonExistingName')->with('New.drawio')->willReturn('New.drawio');
         $dir->expects($this->once())->method('newFile')->with('New.drawio', ' ')->willReturn($file);
-        $this->root->method('getById')->willReturn([$dir]);
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$dir]);
+        $this->root->method('getUserFolder')->willReturn($userFolder);
+        $this->root->expects($this->never())->method('getById');
 
         $result = $this->createController()->create('New.drawio', '5', null);
 
@@ -545,13 +525,13 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testCreateWithoutPermissionReturnsError(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $dir = $this->createMock(Folder::class);
         $dir->method('isCreatable')->willReturn(false);
         $dir->expects($this->never())->method('newFile');
-        $this->root->method('getById')->willReturn([$dir]);
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$dir]);
+        $this->root->method('getUserFolder')->willReturn($userFolder);
 
         $result = $this->createController()->create('New.drawio', '5', null);
 
@@ -559,14 +539,14 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testCreateHandlesNotPermittedException(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $dir = $this->createMock(Folder::class);
         $dir->method('isCreatable')->willReturn(true);
         $dir->method('getNonExistingName')->willReturn('New.drawio');
         $dir->method('newFile')->willThrowException(new NotPermittedException());
-        $this->root->method('getById')->willReturn([$dir]);
+        $userFolder = $this->createMock(Folder::class);
+        $userFolder->method('getById')->willReturn([$dir]);
+        $this->root->method('getUserFolder')->willReturn($userFolder);
 
         $result = $this->createController()->create('New.drawio', '5', null);
 
@@ -656,8 +636,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testGetFileRevisionsListsVersions(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);
@@ -677,8 +655,6 @@ final class EditorControllerTest extends TestCase {
     }
 
     public function testLoadFileVersionReturnsVersionContent(): void {
-        $this->markTestSkipped();
-
         $this->loginAs();
         $file = $this->createFile();
         $this->givenUserFile($file);


### PR DESCRIPTION
## Background

Commit 5bca458 ("Skip unit tests which won't work as expected with mock objects") disabled 19 tests in `EditorControllerTest` with bare `markTestSkipped()` calls. The tests themselves were still valid — they broke for a purely mechanical reason: the security fix (58b45b8) changed id resolution from `IRootFolder::getById()` to `getUserFolder($uid)->getById()`, while the test fixtures stubbed only the root folder. PHPUnit's auto-mocked user folder then returned `[]` for every lookup, so each test hit a 404 before reaching what it actually asserted.

Among the skipped tests were the permission checks (`testLoadUnreadableFileIsForbidden`, `testSaveWithoutWritePermissionIsForbidden`, `testSavePreviewForbiddenWithoutWritePermission`, `testCreateWithoutPermissionReturnsError`) — the closest thing the unit suite has to regression coverage for the security properties the 4.3.6 release fixed.

## What this PR does

* Stubs `getUserFolder()->getById()` instead — in the shared `givenUserFile()` helper for most tests, inline for the tests that build their own folder mocks — and removes the now-dead root `getById()` stubs. All 19 tests pass again **unchanged in what they assert**.
* `testLoadUnknownFileIdIsNotFound` was green only by accident (its root stub was ignored; the auto-mock happened to also produce a 404). It now stubs the user folder explicitly.
* Adds `$this->root->expects($this->never())->method('getById')` to the load and create happy-path tests, locking in the user-folder scoping that fixed GHSA-c9x8-9w2j-4m94 so a future refactor can't quietly reintroduce instance-wide id resolution.
* Reverts the `lib/` half of 5bca458: it had replaced the explanatory comment on the user-folder scoping with a null guard on `getUserFolder()`, which is non-nullable in OCP stable33 (the guard was unreachable, and the auto-mock never returns null either — it wasn't what broke the tests). `getFileById()` is byte-identical to 58b45b8 again, comment included.

Result: `composer run test:unit` — 106 tests, 278 assertions, **0 skipped**.

Note: #58 (folder-share create fix) touches neighbouring test code; whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
